### PR TITLE
Add HKDF support (IETF RFC 5869)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changelog
 * Fixed OAEPEncoding and PKCS1Encoding to use provided output offset value.
 * Fixed RSA block length and offset checks in RSAEngine.processBlock.
 * Fixed RSASigner.verifySignature to return false when signature is bad.
+* Add HKDF support (IETF RFC 5869)
 
 #### Version 1.0.2 (2019-11-15)
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ In this release, the following algorithms are implemented:
   * PBKDF2
   * scrypt
 
+**HMAC based key derivators:**
+  * HKDF
+
 **Asymmetric key generators:**
   * ECDSA
   * RSA

--- a/lib/export.dart
+++ b/lib/export.dart
@@ -55,6 +55,7 @@ export "package:pointycastle/ecc/ecc_base.dart";
 
 // key_derivators
 export "package:pointycastle/key_derivators/api.dart";
+export "package:pointycastle/key_derivators/hkdf.dart";
 export "package:pointycastle/key_derivators/pbkdf2.dart";
 export "package:pointycastle/key_derivators/scrypt.dart";
 

--- a/lib/key_derivators/api.dart
+++ b/lib/key_derivators/api.dart
@@ -25,3 +25,27 @@ class ScryptParameters implements CipherParameters {
 
   ScryptParameters(this.N, this.r, this.p, this.desiredKeyLength, this.salt);
 }
+
+/// Generates [CipherParameters] for HKDF key derivation function.
+class HkdfParameters extends CipherParameters {
+  final Uint8List ikm; // the input keying material or seed
+  final int desiredKeyLength;
+  final Uint8List salt; // the salt to use, may be null for a salt for hashLen zeros
+  final Uint8List info; // the info to use, may be null for an info field of zero bytes
+  final bool skipExtract;
+
+  HkdfParameters._(this.ikm, this.desiredKeyLength,
+      [this.salt, this.info, this.skipExtract = false]);
+
+  factory HkdfParameters(ikm, desiredKeyLength, [salt, info, skipExtract = false]) {
+    if (ikm == null) {
+      throw new ArgumentError("IKM (input keying material) should not be null");
+    }
+
+    if (salt == null || salt.length == 0) {
+      salt = null;
+    }
+
+    return new HkdfParameters._(ikm, desiredKeyLength, salt, info ?? new Uint8List(0), skipExtract);
+  }
+}

--- a/lib/key_derivators/hkdf.dart
+++ b/lib/key_derivators/hkdf.dart
@@ -1,0 +1,171 @@
+// See file LICENSE for more information.
+
+library pointycastle.impl.key_derivator.hkdf;
+
+import "dart:math";
+import "dart:typed_data";
+
+import "package:pointycastle/api.dart";
+import 'package:pointycastle/export.dart';
+import "package:pointycastle/key_derivators/api.dart";
+import "package:pointycastle/src/impl/base_key_derivator.dart";
+import "package:pointycastle/src/registry/registry.dart";
+
+/// HMAC-based Extract-and-Expand Key Derivation Function (HKDF) implemented
+/// according to IETF RFC 5869.
+class HKDFKeyDerivator extends BaseKeyDerivator {
+  /// Intended for internal use.
+  static final FactoryConfig FACTORY_CONFIG =
+      new DynamicFactoryConfig.suffix(KeyDerivator, "/HKDF", (_, Match match) {
+    final String digestName = match.group(1);
+    final Digest digest = new Digest(digestName);
+    return () {
+      return new HKDFKeyDerivator(digest);
+    };
+  });
+
+  static final Map<String, int> _DIGEST_BLOCK_LENGTH = {
+    "GOST3411": 32,
+    "MD2": 16,
+    "MD4": 64,
+    "MD5": 64,
+    "RIPEMD-128": 64,
+    "RIPEMD-160": 64,
+    "SHA-1": 64,
+    "SHA-224": 64,
+    "SHA-256": 64,
+    "SHA-384": 128,
+    "SHA-512": 128,
+    "Tiger": 64,
+    "Whirlpool": 64,
+  };
+
+  HkdfParameters _params;
+
+  HMac _hMac;
+  int _hashLen;
+
+  Uint8List _info;
+  Uint8List _currentT;
+
+  int _generatedBytes;
+
+  HKDFKeyDerivator(Digest digest) {
+    ArgumentError.checkNotNull(digest);
+
+    _hMac = new HMac(digest, _getBlockLengthFromDigest(digest.algorithmName));
+    _hashLen = _hMac.macSize;
+  }
+
+  @override
+  String get algorithmName => "${_hMac.algorithmName}/HKDF";
+
+  @override
+  int get keySize => _params.desiredKeyLength;
+
+  @override
+  void init(covariant HkdfParameters params) {
+    _params = params;
+
+    if (_params.skipExtract) {
+      // use IKM directly as PRK
+      _hMac.init(new KeyParameter(_params.ikm));
+    } else {
+      _hMac.init(extract(_params.salt, _params.ikm));
+    }
+
+    _info = _params.info;
+
+    _generatedBytes = 0;
+    _currentT = new Uint8List(_hashLen);
+  }
+
+  @override
+  int deriveKey(Uint8List inp, int inpOff, Uint8List out, int outOff) {
+    // append input to the 'info' part for key derivation
+    if (inp != null) {
+      _info = Uint8List.fromList(_info + inp);
+    }
+
+    return _generate(out, outOff, keySize);
+  }
+
+  /// Performs the extract part of the key derivation function.
+  KeyParameter extract(Uint8List salt, Uint8List ikm) {
+    if (salt == null || salt.isEmpty) {
+      if (_hashLen != _hMac.macSize) {
+        throw new ArgumentError("Hash length doesn't equal MAC size of: ${_hMac.algorithmName}");
+      }
+
+      _hMac.init(new KeyParameter(new Uint8List(_hashLen)));
+    } else {
+      _hMac.init(new KeyParameter(salt));
+    }
+
+    _hMac.update(ikm, 0, ikm.length);
+
+    Uint8List prk = new Uint8List(_hashLen);
+    _hMac.doFinal(prk, 0);
+    return new KeyParameter(prk);
+  }
+
+  /// Performs the expand part of the key derivation function, using currentT
+  /// as input and output buffer.
+  void expandNext() {
+    int n = _generatedBytes ~/ _hashLen + 1;
+    if (n >= 256) {
+      throw new ArgumentError("HKDF cannot generate more than 255 blocks of HashLen size");
+    }
+
+    // special case for T(0): T(0) is empty, so no update
+    if (_generatedBytes != 0) {
+      _hMac.update(_currentT, 0, _hashLen);
+    }
+
+    _hMac.update(_info, 0, _info.length);
+    _hMac.updateByte(n);
+    _hMac.doFinal(_currentT, 0);
+  }
+
+  int _generate(Uint8List out, int outOff, int len) {
+    if (_generatedBytes + len > 255 * _hashLen) {
+      throw new ArgumentError("HKDF may only be used for 255 * HashLen bytes of output");
+    }
+
+    if (_generatedBytes % _hashLen == 0) {
+      expandNext();
+    }
+
+    // copy what is left in the currentT
+    int toGenerate = len;
+    int posInT = _generatedBytes % _hashLen;
+    int leftInT = _hashLen - _generatedBytes % _hashLen;
+    int toCopy = min(leftInT, toGenerate);
+    out.setRange(outOff, outOff + toCopy, _currentT.sublist(posInT));
+    _generatedBytes += toCopy;
+    toGenerate -= toCopy;
+    outOff += toCopy;
+
+    while (toGenerate > 0) {
+      expandNext();
+      toCopy = min(_hashLen, toGenerate);
+      out.setRange(outOff, outOff + toCopy, _currentT.sublist(0));
+      _generatedBytes += toCopy;
+      toGenerate -= toCopy;
+      outOff += toCopy;
+    }
+
+    return len;
+  }
+
+  static int _getBlockLengthFromDigest(String digestName) {
+    var blockLength = _DIGEST_BLOCK_LENGTH.entries
+        .firstWhere((map) => map.key.toLowerCase() == digestName.toLowerCase(), orElse: null)
+        .value;
+    if (blockLength == null) {
+      throw new ArgumentError("Invalid block length for digest: ${digestName}");
+    }
+
+    return blockLength;
+  }
+}

--- a/lib/src/registry/registration.dart
+++ b/lib/src/registry/registration.dart
@@ -69,6 +69,7 @@ import 'package:pointycastle/ecc/curves/secp256k1.dart';
 import 'package:pointycastle/ecc/curves/secp256r1.dart';
 import 'package:pointycastle/ecc/curves/secp384r1.dart';
 import 'package:pointycastle/ecc/curves/secp521r1.dart';
+import 'package:pointycastle/key_derivators/hkdf.dart';
 import 'package:pointycastle/key_derivators/pbkdf2.dart';
 import 'package:pointycastle/key_derivators/scrypt.dart';
 import 'package:pointycastle/key_generators/ec_key_generator.dart';
@@ -190,6 +191,7 @@ void _registerECCurves(FactoryRegistry registry) {
 void _registerKeyDerivators(FactoryRegistry registry) {
   registry.register(PBKDF2KeyDerivator.FACTORY_CONFIG);
   registry.register(Scrypt.FACTORY_CONFIG);
+  registry.register(HKDFKeyDerivator.FACTORY_CONFIG);
 }
 
 void _registerKeyGenerators(FactoryRegistry registry) {

--- a/test/key_derivators/hkdf_test.dart
+++ b/test/key_derivators/hkdf_test.dart
@@ -1,0 +1,259 @@
+// See file LICENSE for more information.
+
+library pointycastle.test.key_derivators.hkdf_test;
+
+import 'dart:typed_data';
+
+import 'package:pointycastle/export.dart';
+import 'package:pointycastle/key_derivators/hkdf.dart';
+import 'package:pointycastle/pointycastle.dart';
+import 'package:test/test.dart';
+
+import '../test/key_derivators_tests.dart';
+import '../test/src/helpers.dart';
+
+void main() {
+  group("HKDF tests", () {
+    group("derivator tests", () {
+      var ikm = createUint8ListFromString("initial key material");
+      var salt = createUint8ListFromString("salt");
+      var params = new HkdfParameters(ikm, 32, salt);
+      var hkdf = new KeyDerivator("SHA-256/HKDF");
+
+      runKeyDerivatorTests(hkdf, [
+        params,
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit...",
+        "013133aa211d145cbd3f1377259d555c46a9d8a4b04371b9f79b3c9f37c20f9d",
+        params,
+        "En un lugar de La Mancha, de cuyo nombre no quiero acordarme...",
+        "df6d2879dddf56f373e8d052147dbdafe2c7bdfb26ee425a9d5b39587dbe7e0e",
+      ]);
+    });
+
+    // HKDF tests - vectors from RFC 5869
+    group("Test vectors - RFC 5869", () {
+      test("Test Case 1 - Basic test case with SHA-256", () {
+        var ikm = createUint8ListFromHexString("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = createUint8ListFromHexString("000102030405060708090a0b0c");
+        var info = createUint8ListFromHexString("f0f1f2f3f4f5f6f7f8f9");
+        int l = 42;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA256Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "3cb25f25faacd57a90434f64d0362f2a" +
+            "2d2d0a90cf1a5a4c5db02d56ecc4c5bf" +
+            "34007208d5b887185865";
+        expect(actual, equals(expected));
+      });
+
+      test("Test Case 2 - Test with SHA-256 and longer inputs/outputs", () {
+        var ikm = createUint8ListFromHexString("000102030405060708090a0b0c0d0e0f"
+            "101112131415161718191a1b1c1d1e1f"
+            "202122232425262728292a2b2c2d2e2f"
+            "303132333435363738393a3b3c3d3e3f"
+            "404142434445464748494a4b4c4d4e4f");
+        var salt = createUint8ListFromHexString("606162636465666768696a6b6c6d6e6f"
+            "707172737475767778797a7b7c7d7e7f"
+            "808182838485868788898a8b8c8d8e8f"
+            "909192939495969798999a9b9c9d9e9f"
+            "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+        var info = createUint8ListFromHexString("b0b1b2b3b4b5b6b7b8b9babbbcbdbebf"
+            "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+            "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf"
+            "e0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+            "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+        int l = 82;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA256Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "b11e398dc80327a1c8e7f78c596a4934"
+            "4f012eda2d4efad8a050cc4c19afa97c"
+            "59045a99cac7827271cb41c65e590e09"
+            "da3275600c2f09b8367793a9aca3db71"
+            "cc30c58179ec3e87c14c01d5c1f3434f"
+            "1d87";
+        expect(actual, equals(expected));
+      });
+
+      // setting salt to an empty byte array means that the salt is set to
+      // HashLen zero valued bytes
+      // setting info to null generates an empty byte array as info
+      // structure
+      test("Test Case 3 - Test with SHA-256 and zero-length salt/info", () {
+        var ikm = createUint8ListFromHexString("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = new Uint8List(0);
+        var info = null;
+        int l = 42;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA256Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "8da4e775a563c18f715f802a063c5a31"
+            "b8a11f5c5ee1879ec3454e5f3c738d2d"
+            "9d201395faa4b61a96c8";
+        expect(actual, equals(expected));
+      });
+
+      test("Test Case 4 - Basic test case with SHA-1", () {
+        var ikm = createUint8ListFromHexString("0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = createUint8ListFromHexString("000102030405060708090a0b0c");
+        var info = createUint8ListFromHexString("f0f1f2f3f4f5f6f7f8f9");
+        int l = 42;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA1Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "085a01ea1b10f36933068b56efa5ad81"
+            "a4f14b822f5b091568a9cdd4f155fda2"
+            "c22e422478d305f3f896";
+        expect(actual, equals(expected));
+      });
+
+      test("Test Case 5 - Test with SHA-1 and longer inputs/outputs", () {
+        var ikm = createUint8ListFromHexString("000102030405060708090a0b0c0d0e0f" +
+            "101112131415161718191a1b1c1d1e1f" +
+            "202122232425262728292a2b2c2d2e2f" +
+            "303132333435363738393a3b3c3d3e3f" +
+            "404142434445464748494a4b4c4d4e4f");
+        var salt = createUint8ListFromHexString("606162636465666768696a6b6c6d6e6f" +
+            "707172737475767778797a7b7c7d7e7f" +
+            "808182838485868788898a8b8c8d8e8f" +
+            "909192939495969798999a9b9c9d9e9f" +
+            "a0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+        var info = createUint8ListFromHexString("b0b1b2b3b4b5b6b7b8b9babbbcbdbebf" +
+            "c0c1c2c3c4c5c6c7c8c9cacbcccdcecf" +
+            "d0d1d2d3d4d5d6d7d8d9dadbdcdddedf" +
+            "e0e1e2e3e4e5e6e7e8e9eaebecedeeef" +
+            "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+        int l = 82;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA1Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "0bd770a74d1160f7c9f12cd5912a06eb" +
+            "ff6adcae899d92191fe4305673ba2ffe" +
+            "8fa3f1a4e5ad79f3f334b3b202b2173c" +
+            "486ea37ce3d397ed034c7f9dfeb15c5e" +
+            "927336d0441f4c4300e2cff0d0900b52" +
+            "d3b4";
+        expect(actual, equals(expected));
+      });
+
+      // setting salt to null should generate a new salt of HashLen zero valued bytes
+      test("Test Case 6 - Test with SHA-1 and zero-length salt/info", () {
+        var ikm = createUint8ListFromHexString("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        var salt = null;
+        var info = new Uint8List(0);
+        int l = 42;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA1Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "0ac1af7002b3d761d1e55298da9d0506" +
+            "b9ae52057220a306e07b6b87e8df21d0" +
+            "ea00033de03984d34918";
+        expect(actual, equals(expected));
+      });
+
+      // this test is identical to test 6 in all ways bar the IKM value
+      test("Test Case 7 - Test with SHA-1, salt not provided, zero-length info", () {
+        var ikm = createUint8ListFromHexString("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c");
+        var salt = null;
+        var info = new Uint8List(0);
+        int l = 42;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, salt, info);
+
+        var hkdf = new HKDFKeyDerivator(new SHA1Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "2c91117204d745f3500d636a62f64f0a" +
+            "b3bae548aa53d423b0d1f27ebba6f5e5" +
+            "673a081d70cce7acfc48";
+        expect(actual, equals(expected));
+      });
+
+      // this test is identical to test 7 in all ways bar the IKM value
+      // which is set to the PRK value
+      test("Additional Test Case - Test with SHA-1, skipping extract zero-length info", () {
+        var ikm = createUint8ListFromHexString("2adccada18779e7c2077ad2eb19d3f3e731385dd");
+        var info = new Uint8List(0);
+        int l = 42;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, null, info, true);
+
+        var hkdf = new HKDFKeyDerivator(new SHA1Digest());
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        var actual = formatBytesAsHexString(okm);
+        var expected = "2c91117204d745f3500d636a62f64f0a" +
+            "b3bae548aa53d423b0d1f27ebba6f5e5" +
+            "673a081d70cce7acfc48";
+        expect(actual, equals(expected));
+      });
+
+      // this test is identical to test 7 in all ways bar the IKM value
+      test("Additional Test Case - Test with SHA-1, maximum output", () {
+        var hash = new SHA1Digest();
+        var ikm = createUint8ListFromHexString("2adccada18779e7c2077ad2eb19d3f3e731385dd");
+        var info = new Uint8List(0);
+        int l = 255 * hash.digestSize;
+        var okm = new Uint8List(l);
+
+        var params = new HkdfParameters(ikm, l, null, info, true);
+
+        var hkdf = new HKDFKeyDerivator(hash);
+        hkdf.init(params);
+        hkdf.deriveKey(null, 0, okm, 0);
+
+        int zeros = 0;
+        for (int i = 0; i < hash.digestSize; i++) {
+          if (okm[i] == 0) {
+            zeros++;
+          }
+        }
+
+        if (zeros == hash.digestSize) {
+          fail("HKDF failed generator test A.102");
+        }
+      });
+    });
+  });
+}


### PR DESCRIPTION
Added an implementation of HMAC-based Extract-and-Expand Key Derivation Function according to IETF RFC 5869. It is based on the HKDF from Bouncy Castle Crypto package for Java.