### PR TITLE
[utils] Optional leading padding in BigInt

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -5,3 +5,4 @@
 
 Iván Zaera Avellón <izaera@gmail.com>
 Steven Roose <stevenroose@gmail.com>
+Jean-Baptiste Dominguez <jeanbaptiste.dominguez@gmail.com>

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -16,9 +16,11 @@ BigInt decodeBigInt(List<int> bytes) {
 var _byteMask = new BigInt.from(0xff);
 
 /// Encode a BigInt into bytes using big-endian encoding.
-Uint8List encodeBigInt(BigInt number) {
+/// Provide a minimum byte length `minByteLength`
+Uint8List encodeBigInt(BigInt number, {int minByteLength = 0}) {
   // Not handling negative numbers. Decide how you want to do that.
   int size = (number.bitLength + 7) >> 3;
+  size = minByteLength > size ? minByteLength : size;
   var result = new Uint8List(size);
   for (int i = 0; i < size; i++) {
     result[size - i - 1] = (number & _byteMask).toInt();


### PR DESCRIPTION
## Context
When I sign using `pc-dart`, it can happen that my signature `r` and `s` do not have a length of **32** bytes but **31** bytes.
https://github.com/jbdtky/bip32-dart/blob/master/lib/src/utils/ecurve.dart#L128

## Proposal
When I encode a big int using `pc-dart`, I would like to provide an optional parameter `minByteLength` in order to have automatically a leading padding on my `Uint8List`.
So I upgraded the pc-dart lib utils with this option.