### PR TITLE
Fix nearly 3000 linter warnings in lib/digest

### DIFF
--- a/lib/digests/ripemd128.dart
+++ b/lib/digests/ripemd128.dart
@@ -2,25 +2,29 @@
 
 library impl.digest.ripemd128;
 
-import "dart:typed_data";
+import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/src/impl/md4_family_digest.dart";
-import "package:pointycastle/src/registry/registry.dart";
-import "package:pointycastle/src/ufixnum.dart";
+import 'package:pointycastle/api.dart';
+import 'package:pointycastle/src/impl/md4_family_digest.dart';
+import 'package:pointycastle/src/registry/registry.dart';
+import 'package:pointycastle/src/ufixnum.dart';
 
 /// Implementation of RIPEMD-128 digest
 class RIPEMD128Digest extends MD4FamilyDigest implements Digest {
   static final FactoryConfig FACTORY_CONFIG =
-      new StaticFactoryConfig(Digest, "RIPEMD-128", () => RIPEMD128Digest());
+      StaticFactoryConfig(Digest, 'RIPEMD-128', () => RIPEMD128Digest());
 
   static const _DIGEST_LENGTH = 16;
 
   RIPEMD128Digest() : super(Endian.little, 4, 16);
 
-  final algorithmName = "RIPEMD-128";
+  @override
+  final algorithmName = 'RIPEMD-128';
+
+  @override
   final digestSize = _DIGEST_LENGTH;
 
+  @override
   void resetState() {
     state[0] = 0x67452301;
     state[1] = 0xefcdab89;
@@ -28,11 +32,12 @@ class RIPEMD128Digest extends MD4FamilyDigest implements Digest {
     state[3] = 0x10325476;
   }
 
+  @override
   void processBlock() {
-    var a, aa;
-    var b, bb;
-    var c, cc;
-    var d, dd;
+    int a, aa;
+    int b, bb;
+    int c, cc;
+    int d, dd;
 
     a = aa = state[0];
     b = bb = state[1];

--- a/lib/digests/ripemd160.dart
+++ b/lib/digests/ripemd160.dart
@@ -2,25 +2,29 @@
 
 library impl.digest.ripemd160;
 
-import "dart:typed_data";
+import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/src/impl/md4_family_digest.dart";
-import "package:pointycastle/src/registry/registry.dart";
-import "package:pointycastle/src/ufixnum.dart";
+import 'package:pointycastle/api.dart';
+import 'package:pointycastle/src/impl/md4_family_digest.dart';
+import 'package:pointycastle/src/registry/registry.dart';
+import 'package:pointycastle/src/ufixnum.dart';
 
 /// Implementation of RIPEMD-160 digest.
 class RIPEMD160Digest extends MD4FamilyDigest implements Digest {
   static final FactoryConfig FACTORY_CONFIG =
-      new StaticFactoryConfig(Digest, "RIPEMD-160", () => RIPEMD160Digest());
+      StaticFactoryConfig(Digest, 'RIPEMD-160', () => RIPEMD160Digest());
 
   static const _DIGEST_LENGTH = 20;
 
   RIPEMD160Digest() : super(Endian.little, 5, 16);
 
-  final algorithmName = "RIPEMD-160";
+  @override
+  final algorithmName = 'RIPEMD-160';
+
+  @override
   final digestSize = _DIGEST_LENGTH;
 
+  @override
   void resetState() {
     state[0] = 0x67452301;
     state[1] = 0xefcdab89;
@@ -29,12 +33,13 @@ class RIPEMD160Digest extends MD4FamilyDigest implements Digest {
     state[4] = 0xc3d2e1f0;
   }
 
+  @override
   void processBlock() {
-    var a, aa;
-    var b, bb;
-    var c, cc;
-    var d, dd;
-    var e, ee;
+    int a, aa;
+    int b, bb;
+    int c, cc;
+    int d, dd;
+    int e, ee;
 
     a = aa = state[0];
     b = bb = state[1];

--- a/lib/digests/ripemd256.dart
+++ b/lib/digests/ripemd256.dart
@@ -2,25 +2,29 @@
 
 library impl.digest.ripemd256;
 
-import "dart:typed_data";
+import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/src/impl/md4_family_digest.dart";
-import "package:pointycastle/src/registry/registry.dart";
-import "package:pointycastle/src/ufixnum.dart";
+import 'package:pointycastle/api.dart';
+import 'package:pointycastle/src/impl/md4_family_digest.dart';
+import 'package:pointycastle/src/registry/registry.dart';
+import 'package:pointycastle/src/ufixnum.dart';
 
 /// Implementation of RIPEMD-256 digest.
 class RIPEMD256Digest extends MD4FamilyDigest implements Digest {
   static final FactoryConfig FACTORY_CONFIG =
-      new StaticFactoryConfig(Digest, "RIPEMD-256", () => RIPEMD256Digest());
+      StaticFactoryConfig(Digest, 'RIPEMD-256', () => RIPEMD256Digest());
 
   static const _DIGEST_LENGTH = 32;
 
   RIPEMD256Digest() : super(Endian.little, 8, 16);
 
-  final algorithmName = "RIPEMD-256";
+  @override
+  final algorithmName = 'RIPEMD-256';
+
+  @override
   final digestSize = _DIGEST_LENGTH;
 
+  @override
   void resetState() {
     state[0] = 0x67452301;
     state[1] = 0xefcdab89;
@@ -32,12 +36,13 @@ class RIPEMD256Digest extends MD4FamilyDigest implements Digest {
     state[7] = 0x01234567;
   }
 
+  @override
   void processBlock() {
-    var a, aa;
-    var b, bb;
-    var c, cc;
-    var d, dd;
-    var t;
+    int a, aa;
+    int b, bb;
+    int c, cc;
+    int d, dd;
+    int t;
 
     a = state[0];
     b = state[1];

--- a/lib/digests/ripemd320.dart
+++ b/lib/digests/ripemd320.dart
@@ -2,25 +2,28 @@
 
 library impl.digest.ripemd320;
 
-import "dart:typed_data";
+import 'dart:typed_data';
 
-import "package:pointycastle/api.dart";
-import "package:pointycastle/src/impl/md4_family_digest.dart";
-import "package:pointycastle/src/registry/registry.dart";
-import "package:pointycastle/src/ufixnum.dart";
+import 'package:pointycastle/api.dart';
+import 'package:pointycastle/src/impl/md4_family_digest.dart';
+import 'package:pointycastle/src/registry/registry.dart';
+import 'package:pointycastle/src/ufixnum.dart';
 
 /// Implementation of RIPEMD-320 digest.
 class RIPEMD320Digest extends MD4FamilyDigest implements Digest {
   static final FactoryConfig FACTORY_CONFIG =
-      new StaticFactoryConfig(Digest, "RIPEMD-320", () => RIPEMD320Digest());
+      StaticFactoryConfig(Digest, 'RIPEMD-320', () => RIPEMD320Digest());
 
   static const _DIGEST_LENGTH = 40;
 
   RIPEMD320Digest() : super(Endian.little, 10, 16);
+  @override
+  final algorithmName = 'RIPEMD-320';
 
-  final algorithmName = "RIPEMD-320";
+  @override
   final digestSize = _DIGEST_LENGTH;
 
+  @override
   void resetState() {
     state[0] = 0x67452301;
     state[1] = 0xefcdab89;
@@ -34,13 +37,14 @@ class RIPEMD320Digest extends MD4FamilyDigest implements Digest {
     state[9] = 0x3C2D1E0F;
   }
 
+  @override
   void processBlock() {
-    var a, aa;
-    var b, bb;
-    var c, cc;
-    var d, dd;
-    var e, ee;
-    var t;
+    int a, aa;
+    int b, bb;
+    int c, cc;
+    int d, dd;
+    int e, ee;
+    int t;
 
     a = state[0];
     b = state[1];


### PR DESCRIPTION
I fixed around 3000 linter warnings including following warnings

- Only use double quotes for strings containing single quotes.
- Unnecessary new keyword.
- Prefer typing uninitialized variables and fields.
- Annotate overridden members.

There are still some warnings :

- Name non-constant identifiers using lowerCamelCase.

This will be not changed yet, due to the chance is higher that this will affect other parts of the code or will break some already used code.

Output of unit tests

pub run test
00:51 +361: All tests passed!       