### PR TITLE
ChaCha20 Support IV/Nonce of 12 bytes instead of 8

### DIFF
--- a/lib/src/api/parameters_with_iv.dart
+++ b/lib/src/api/parameters_with_iv.dart
@@ -14,3 +14,14 @@ class ParametersWithIV<UnderlyingParameters extends CipherParameters>
 
   ParametersWithIV(this.parameters, this.iv);
 }
+
+/// Adds an additional initial counter for [ChaCha20Engine].
+class ParametersWithIVAndInitialCounter<
+        UnderlyingParameters extends CipherParameters>
+    extends ParametersWithIV<UnderlyingParameters> {
+  final int initialCounter;
+
+  ParametersWithIVAndInitialCounter(
+      UnderlyingParameters parameters, Uint8List iv, this.initialCounter)
+      : super(parameters, iv);
+}

--- a/lib/stream/chacha20.dart
+++ b/lib/stream/chacha20.dart
@@ -100,8 +100,8 @@ class ChaCha20Engine extends BaseStreamCipher {
       covariant ParametersWithIV<KeyParameter> params) {
     var uparams = params.parameters;
     var iv = params.iv;
-    if (iv == null || iv.length != 8) {
-      throw ArgumentError('ChaCha20 requires exactly 8 bytes of IV');
+    if (iv == null || (iv.length != 8 && iv.length != 12)) {
+      throw ArgumentError('ChaCha20 requires exactly 8 or 12 bytes of IV');
     }
 
     _workingIV = iv;
@@ -188,9 +188,16 @@ class ChaCha20Engine extends BaseStreamCipher {
     _state[3] = unpack32(constants, 12, Endian.little);
 
     // IV
-    _state[14] = unpack32(_workingIV, 0, Endian.little);
-    _state[15] = unpack32(_workingIV, 4, Endian.little);
-    _state[12] = _state[13] = 0;
+    if (_workingIV.length == 8) {
+      _state[12] = _state[13] = 0;
+      _state[14] = unpack32(_workingIV, 0, Endian.little);
+      _state[15] = unpack32(_workingIV, 4, Endian.little);
+    } else {
+      _state[12] = 0;
+      _state[13] = unpack32(_workingIV, 0, Endian.little);
+      _state[14] = unpack32(_workingIV, 4, Endian.little);
+      _state[15] = unpack32(_workingIV, 8, Endian.little);
+    }
 
     _initialised = true;
   }

--- a/test/stream/chacha20_test.dart
+++ b/test/stream/chacha20_test.dart
@@ -2,10 +2,12 @@
 
 library test.stream.chacha20_test;
 
+import 'dart:convert';
 import "dart:typed_data";
 
 import "package:pointycastle/pointycastle.dart";
 import 'package:pointycastle/stream/chacha20.dart';
+import 'package:test/test.dart';
 
 import "../test/src/helpers.dart";
 
@@ -97,6 +99,35 @@ void main() {
   chachaTest1(20, ParametersWithIV(KeyParameter(createUint8ListFromHexString("00400000000000000000000000000000")), createUint8ListFromHexString("0000000000000000")), set1v9_0, set1v9_192,  set1v9_256,  set1v9_448);
   chachaTest1(12, ParametersWithIV(KeyParameter(createUint8ListFromHexString("80000000000000000000000000000000")), createUint8ListFromHexString("0000000000000000")), chacha12_set1v0_0, chacha12_set1v0_192,  chacha12_set1v0_256,  chacha12_set1v0_448);
   chachaTest1(8, ParametersWithIV(KeyParameter(createUint8ListFromHexString("80000000000000000000000000000000")), createUint8ListFromHexString("0000000000000000")), chacha8_set1v0_0, chacha8_set1v0_192,  chacha8_set1v0_256,  chacha8_set1v0_448);
+  test('rfc 7539 example', () {
+    // Example from RFC 7539
+    //   - 2.4.2.  Example and Test Vector for the ChaCha20 Cipher
+    //   o  Key = 00:01:02:03:04:05:06:07:08:09:0a:0b:0c:0d:0e:0f:10:11:12:13:
+    //      14:15:16:17:18:19:1a:1b:1c:1d:1e:1f.
+    //
+    //   o  Nonce = (00:00:00:00:00:00:00:4a:00:00:00:00).
+    //
+    //   o  Initial Counter = 1.
+    final expected = ''' 6e 2e 35 9a 25 68 f9 80 41 ba 07 28 dd 0d 69 81 
+e9 7e 7a ec 1d 43 60 c2 0a 27 af cc fd 9f ae 0b 
+f9 1b 65 c5 52 47 33 ab 8f 59 3d ab cd 62 b3 57 
+16 39 d6 24 e6 51 52 ab 8f 53 0c 35 9f 08 61 d8 
+07 ca 0d bf 50 0d 6a 61 56 a3 8e 08 8a 22 b6 5e 
+52 bc 51 4d 16 cc f8 06 81 8c e9 1a b7 79 37 36 
+5a f9 0b bf 74 a3 5b e6 b4 0b 8e ed f2 78 5e 42 
+87 4d                                           '''
+        .replaceAll(RegExp(r'\s'), '');
+    final source =
+        'Ladies and Gentlemen of the class of \'99: If I could offer you only one tip for the future, sunscreen would be it.';
+    final nonce = createUint8ListFromHexString('000000000000004a00000000');
+    final key = createUint8ListFromHexString(
+        '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f');
+    final inp = utf8.encode(source) as Uint8List;
+    final chacha20 = ChaCha20Engine()
+      ..init(true, ParametersWithIV(KeyParameter(key), nonce));
+    final result = chacha20.process(inp);
+    expect(formatBytesAsHexString(result), expected);
+  });
 }
 
 void chachaTest1(int rounds, CipherParameters params, String v0, String v192, String v256, String v448) {

--- a/test/stream/chacha20_test.dart
+++ b/test/stream/chacha20_test.dart
@@ -124,7 +124,8 @@ f9 1b 65 c5 52 47 33 ab 8f 59 3d ab cd 62 b3 57
         '000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f');
     final inp = utf8.encode(source) as Uint8List;
     final chacha20 = ChaCha20Engine()
-      ..init(true, ParametersWithIV(KeyParameter(key), nonce));
+      ..init(
+          true, ParametersWithIVAndInitialCounter(KeyParameter(key), nonce, 1));
     final result = chacha20.process(inp);
     expect(formatBytesAsHexString(result), expected);
   });


### PR DESCRIPTION
According to https://tools.ietf.org/html/rfc7539 the input to chacha20 can include

>   o  A 96-bit nonce.  In some protocols, this is known as the Initialization Vector."

I have added support fo 12 bytes (previously only 8 bytes, ie. 64 bits was supported).

The second commit also adds a way to customize the "Initial Counter" which is basically only required so  I can include the [same test as the RFC for the encryption](https://tools.ietf.org/html/rfc7539#section-2.4.2), which starts at 1.