### PR TITLE
Remove external keyword from noSuchMethod() in ChaCha7539 and ChaCha20

### DIFF
--- a/lib/stream/chacha20.dart
+++ b/lib/stream/chacha20.dart
@@ -313,5 +313,5 @@ class ChaCha20Engine extends BaseStreamCipher {
   }
 
   @override
-  external dynamic noSuchMethod(Invocation invocation);
+  dynamic noSuchMethod(Invocation invocation);
 }

--- a/lib/stream/chacha7539.dart
+++ b/lib/stream/chacha7539.dart
@@ -310,5 +310,5 @@ class ChaCha7539Engine extends BaseStreamCipher {
   }
 
   @override
-  external dynamic noSuchMethod(Invocation invocation);
+  dynamic noSuchMethod(Invocation invocation);
 }


### PR DESCRIPTION
The external keyword in the above two engines causes dart2js to fail with:
```
Error: Only external js-interop functions are supported. Try removing 'external' keyword or annotating the function as a js-interop function.
```
I tried removing the `external` keyword and didn't notice any issues so that's what I've done here.

Getting this fixed is important for Flutter web apps to use pointycastle so if this isn't the right solution I hope one can be found.