### PR TITLE
fix: remove dart:io dependency to allow compiling for web/flutter_web

### DIFF
--- a/lib/digests/keccak.dart
+++ b/lib/digests/keccak.dart
@@ -2,7 +2,6 @@
 
 library impl.digest.keccak;
 
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:pointycastle/api.dart';

--- a/test/digests/keccak_test.dart
+++ b/test/digests/keccak_test.dart
@@ -2,7 +2,6 @@
 
 library test.digests.keccak_test;
 
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:pointycastle/digests/keccak.dart';


### PR DESCRIPTION
I have a build that started failing recently with the following error when using build_runner:

```
[WARNING] build_web_compilers:entrypoint on test/encrypt_codec_test.dart.browser_test.dart:
Skipping compiling sembast|test/encrypt_codec_test.dart.browser_test.dart with ddc because some of its
transitive libraries have sdk dependencies that not supported on this platform:

pointycastle|lib/digests/keccak.dart

https://github.com/dart-lang/build/blob/master/docs/faq.md#how-can-i-resolve-skipped-compiling-warnings
```

I used to be able to use this very convenient library on the web.

There seems to be an extra `dart:io` import (unused too) that is [causing an issue recently](https://travis-ci.org/github/tekartik/sembast.dart/jobs/737791660). Dart analysis also reports several other errors that might be worth looking at. Maybe adding some test in travis (dart test -p chrome / build_runner test) could also help ensuring that it works on the web.

My pull request is just about removing those unused dart.io imports.