### PR TITLE
Add missing secp384r1 identifier

### DIFF
--- a/lib/asn1/object_identifiers.dart
+++ b/lib/asn1/object_identifiers.dart
@@ -256,6 +256,11 @@ class ObjectIdentifiers {
       'readableName': 'GN',
       'identifier': [2, 5, 4, 42]
     },
+    {
+      'identifierString': '1.3.132.0.34',
+      'readableName': 'secp384r1',
+      'identifier': [1, 3, 132, 0, 34],
+    },
   ];
 
   ///


### PR DESCRIPTION
I'm using PointyCastle to generate secp384r1 keys.