### PR TITLE
Added optional fixed output size to encodeBigInt

### DIFF
--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -26,12 +26,14 @@ BigInt decodeBigInt(List<int> bytes) {
 var _byteMask = BigInt.from(0xff);
 
 /// Encode a BigInt into bytes using big-endian encoding.
-Uint8List encodeBigInt(BigInt number) {
+Uint8List encodeBigInt(BigInt number, [int fitSize]) {
   // Not handling negative numbers. Decide how you want to do that.
   var size = (number.bitLength + 7) >> 3;
-  var result = Uint8List(size);
+  fitSize =
+      fitSize ?? size; //use fitSize if defined otherwise use computed size
+  var result = Uint8List(fitSize);
   for (var i = 0; i < size; i++) {
-    result[size - i - 1] = (number & _byteMask).toInt();
+    result[fitSize - i - 1] = (number & _byteMask).toInt();
     number = number >> 8;
   }
   return result;


### PR DESCRIPTION
ref: [copied from this pull request](https://github.com/PointyCastle/pointycastle/pull/181)
"got a bug in a program where the r value was 31 bytes but code expected 32 bytes. this will pad with leading 0s if fixed size is set."