### PR TITLE
Remove unused dart:io import

### DIFF
--- a/lib/digests/keccak.dart
+++ b/lib/digests/keccak.dart
@@ -2,7 +2,6 @@
 
 library impl.digest.keccak;
 
-import 'dart:io';
 import 'dart:typed_data';
 
 import 'package:pointycastle/api.dart';


### PR DESCRIPTION
Remove the unused dart:io import, to allow the package to be used in a javascript environment like UI made with dart or Flutter Web.