### PR TITLE
Fixed small bug in the decodeLength function of the ASN1Utils class

### DIFF
--- a/lib/asn1/asn1_utils.dart
+++ b/lib/asn1/asn1_utils.dart
@@ -29,7 +29,7 @@ class ASN1Utils {
   static int decodeLength(Uint8List encodedBytes) {
     var valueStartPosition = 2;
     var length = encodedBytes[1];
-    if (length < 0x7F) {
+    if (length <= 0x7F) {
       return length;
     }
     if (length == 0x80) {


### PR DESCRIPTION
Hello,

I fixed a small bug in the decodeLength function of the ASN1Utils class. The length was not decoded correctly if the length is 127. This caused a problem in my Basic Utils Package while trying to parse a X509 pem with some ASN1 objects with length of 127.
