### PR TITLE
fix construction of ECCurves with nullsafety

### DIFF
--- a/lib/ecc/curves/brainpoolp160r1.dart
+++ b/lib/ecc/curves/brainpoolp160r1.dart
@@ -25,10 +25,10 @@ class ECCurve_brainpoolp160r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp160r1;
 
   static ECCurve_brainpoolp160r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp160r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp160r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp160t1.dart
+++ b/lib/ecc/curves/brainpoolp160t1.dart
@@ -25,10 +25,10 @@ class ECCurve_brainpoolp160t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp160t1;
 
   static ECCurve_brainpoolp160t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp160t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp160t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp192r1.dart
+++ b/lib/ecc/curves/brainpoolp192r1.dart
@@ -29,10 +29,10 @@ class ECCurve_brainpoolp192r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp192r1;
 
   static ECCurve_brainpoolp192r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp192r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp192r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp192t1.dart
+++ b/lib/ecc/curves/brainpoolp192t1.dart
@@ -29,10 +29,10 @@ class ECCurve_brainpoolp192t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp192t1;
 
   static ECCurve_brainpoolp192t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp192t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp192t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp224r1.dart
+++ b/lib/ecc/curves/brainpoolp224r1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp224r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp224r1;
 
   static ECCurve_brainpoolp224r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp224r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp224r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp224t1.dart
+++ b/lib/ecc/curves/brainpoolp224t1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp224t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp224t1;
 
   static ECCurve_brainpoolp224t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt? _h, List<int>? seed) =>
       ECCurve_brainpoolp224t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp224t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt? _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp256r1.dart
+++ b/lib/ecc/curves/brainpoolp256r1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp256r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp256r1;
 
   static ECCurve_brainpoolp256r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp256r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp256r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp256t1.dart
+++ b/lib/ecc/curves/brainpoolp256t1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp256t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp256t1;
 
   static ECCurve_brainpoolp256t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp256t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp256t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp320r1.dart
+++ b/lib/ecc/curves/brainpoolp320r1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp320r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp320r1;
 
   static ECCurve_brainpoolp320r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp320r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp320r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp320t1.dart
+++ b/lib/ecc/curves/brainpoolp320t1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp320t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp320t1;
 
   static ECCurve_brainpoolp320t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp320t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp320t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp384r1.dart
+++ b/lib/ecc/curves/brainpoolp384r1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp384r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp384r1;
 
   static ECCurve_brainpoolp384r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp384r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp384r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp384t1.dart
+++ b/lib/ecc/curves/brainpoolp384t1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp384t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp384t1;
 
   static ECCurve_brainpoolp384t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp384t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp384t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp512r1.dart
+++ b/lib/ecc/curves/brainpoolp512r1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp512r1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp512r1;
 
   static ECCurve_brainpoolp512r1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp512r1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp512r1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/brainpoolp512t1.dart
+++ b/lib/ecc/curves/brainpoolp512t1.dart
@@ -33,10 +33,10 @@ class ECCurve_brainpoolp512t1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_brainpoolp512t1;
 
   static ECCurve_brainpoolp512t1 _make(String domainName, ECCurve curve,
-          ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_brainpoolp512t1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_brainpoolp512t1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/gostr3410_2001_cryptopro_a.dart
+++ b/lib/ecc/curves/gostr3410_2001_cryptopro_a.dart
@@ -33,11 +33,11 @@ class ECCurve_gostr3410_2001_cryptopro_a extends ECDomainParametersImpl {
       seed: null) as ECCurve_gostr3410_2001_cryptopro_a;
 
   static ECCurve_gostr3410_2001_cryptopro_a _make(String domainName,
-          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_gostr3410_2001_cryptopro_a._super(
           domainName, curve, G, n, _h, seed);
 
   ECCurve_gostr3410_2001_cryptopro_a._super(String domainName, ECCurve curve,
-      ECPoint G, BigInt n, BigInt _h, List<int> seed)
+      ECPoint G, BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/gostr3410_2001_cryptopro_b.dart
+++ b/lib/ecc/curves/gostr3410_2001_cryptopro_b.dart
@@ -35,11 +35,11 @@ class ECCurve_gostr3410_2001_cryptopro_b extends ECDomainParametersImpl {
       seed: null) as ECCurve_gostr3410_2001_cryptopro_b;
 
   static ECCurve_gostr3410_2001_cryptopro_b _make(String domainName,
-          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_gostr3410_2001_cryptopro_b._super(
           domainName, curve, G, n, _h, seed);
 
   ECCurve_gostr3410_2001_cryptopro_b._super(String domainName, ECCurve curve,
-      ECPoint G, BigInt n, BigInt _h, List<int> seed)
+      ECPoint G, BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/gostr3410_2001_cryptopro_c.dart
+++ b/lib/ecc/curves/gostr3410_2001_cryptopro_c.dart
@@ -33,11 +33,11 @@ class ECCurve_gostr3410_2001_cryptopro_c extends ECDomainParametersImpl {
       seed: null) as ECCurve_gostr3410_2001_cryptopro_c;
 
   static ECCurve_gostr3410_2001_cryptopro_c _make(String domainName,
-          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_gostr3410_2001_cryptopro_c._super(
           domainName, curve, G, n, _h, seed);
 
   ECCurve_gostr3410_2001_cryptopro_c._super(String domainName, ECCurve curve,
-      ECPoint G, BigInt n, BigInt _h, List<int> seed)
+      ECPoint G, BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/gostr3410_2001_cryptopro_xcha.dart
+++ b/lib/ecc/curves/gostr3410_2001_cryptopro_xcha.dart
@@ -34,11 +34,11 @@ class ECCurve_gostr3410_2001_cryptopro_xcha extends ECDomainParametersImpl {
       seed: null) as ECCurve_gostr3410_2001_cryptopro_xcha;
 
   static ECCurve_gostr3410_2001_cryptopro_xcha _make(String domainName,
-          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_gostr3410_2001_cryptopro_xcha._super(
           domainName, curve, G, n, _h, seed);
 
   ECCurve_gostr3410_2001_cryptopro_xcha._super(String domainName, ECCurve curve,
-      ECPoint G, BigInt n, BigInt _h, List<int> seed)
+      ECPoint G, BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/gostr3410_2001_cryptopro_xchb.dart
+++ b/lib/ecc/curves/gostr3410_2001_cryptopro_xchb.dart
@@ -34,11 +34,11 @@ class ECCurve_gostr3410_2001_cryptopro_xchb extends ECDomainParametersImpl {
       seed: null) as ECCurve_gostr3410_2001_cryptopro_xchb;
 
   static ECCurve_gostr3410_2001_cryptopro_xchb _make(String domainName,
-          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int> seed) =>
+          ECCurve curve, ECPoint G, BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_gostr3410_2001_cryptopro_xchb._super(
           domainName, curve, G, n, _h, seed);
 
   ECCurve_gostr3410_2001_cryptopro_xchb._super(String domainName, ECCurve curve,
-      ECPoint G, BigInt n, BigInt _h, List<int> seed)
+      ECPoint G, BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/secp160k1.dart
+++ b/lib/ecc/curves/secp160k1.dart
@@ -25,10 +25,10 @@ class ECCurve_secp160k1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_secp160k1;
 
   static ECCurve_secp160k1 _make(String domainName, ECCurve curve, ECPoint G,
-          BigInt n, BigInt _h, List<int> seed) =>
+          BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_secp160k1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_secp160k1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/secp192k1.dart
+++ b/lib/ecc/curves/secp192k1.dart
@@ -27,10 +27,10 @@ class ECCurve_secp192k1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_secp192k1;
 
   static ECCurve_secp192k1 _make(String domainName, ECCurve curve, ECPoint G,
-          BigInt n, BigInt _h, List<int> seed) =>
+          BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_secp192k1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_secp192k1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/secp224k1.dart
+++ b/lib/ecc/curves/secp224k1.dart
@@ -29,10 +29,10 @@ class ECCurve_secp224k1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_secp224k1;
 
   static ECCurve_secp224k1 _make(String domainName, ECCurve curve, ECPoint G,
-          BigInt n, BigInt _h, List<int> seed) =>
+          BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_secp224k1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_secp224k1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/lib/ecc/curves/secp256k1.dart
+++ b/lib/ecc/curves/secp256k1.dart
@@ -29,10 +29,10 @@ class ECCurve_secp256k1 extends ECDomainParametersImpl {
       seed: null) as ECCurve_secp256k1;
 
   static ECCurve_secp256k1 _make(String domainName, ECCurve curve, ECPoint G,
-          BigInt n, BigInt _h, List<int> seed) =>
+          BigInt n, BigInt _h, List<int>? seed) =>
       ECCurve_secp256k1._super(domainName, curve, G, n, _h, seed);
 
   ECCurve_secp256k1._super(String domainName, ECCurve curve, ECPoint G,
-      BigInt n, BigInt _h, List<int> seed)
+      BigInt n, BigInt _h, List<int>? seed)
       : super(domainName, curve, G, n, _h, seed);
 }

--- a/test/ecc/curves.dart
+++ b/test/ecc/curves.dart
@@ -1,0 +1,54 @@
+import 'package:test/test.dart';
+import 'package:pointycastle/export.dart';
+
+void main() {
+  group('ECCurve tests', () {
+    test('ECCurve constructors', () {
+      ECCurve_brainpoolp160r1();
+      ECCurve_brainpoolp160t1();
+      ECCurve_brainpoolp192r1();
+      ECCurve_brainpoolp192t1();
+      ECCurve_brainpoolp224r1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+      ECCurve_brainpoolp224t1();
+
+      ECCurve_gostr3410_2001_cryptopro_a();
+      ECCurve_gostr3410_2001_cryptopro_b();
+      ECCurve_gostr3410_2001_cryptopro_c();
+      ECCurve_gostr3410_2001_cryptopro_xcha();
+      ECCurve_gostr3410_2001_cryptopro_xchb();
+
+      ECCurve_prime192v1();
+      ECCurve_prime192v2();
+      ECCurve_prime192v3();
+      ECCurve_prime239v1();
+      ECCurve_prime239v2();
+      ECCurve_prime239v3();
+      ECCurve_prime256v1();
+
+      ECCurve_secp112r1();
+      ECCurve_secp112r2();
+      ECCurve_secp128r1();
+      ECCurve_secp128r2();
+      ECCurve_secp160k1();
+      ECCurve_secp160r1();
+      ECCurve_secp160r2();
+      ECCurve_secp192k1();
+      ECCurve_secp192r1();
+      ECCurve_secp224k1();
+      ECCurve_secp224r1();
+      ECCurve_secp256k1();
+      ECCurve_secp256r1();
+      ECCurve_secp384r1();
+      ECCurve_secp521r1();
+    });
+  });
+}


### PR DESCRIPTION
Construction of most ECCurves fails because seed is null which is not allowed by the signature of the factory function