### PR TITLE
SHA3 usage description was fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ or like this `StreamCipher('AES/SomeStreamModeHere')`. See sections below for mo
   * 'SHA-224|256|384|512'
   * 'SHA-512/t' (t=8 to 376 and 392 to 504 in multiples of 8)
   * 'Keccak/224|256|384|512'
-  * 'SHA-3/224|256|384|512'
+  * 'SHA3-224|256|384|512'
   * 'Tiger'
   * 'Whirlpool'
 


### PR DESCRIPTION
Current description of SHA3 calling through `Digest` factory assuming creation of SHA3 instances in format 'SHA-3/224|256|384|512' that means call `final sha3 = Digest("SHA-3/256")` should work, but instead it throws exception. The actual calling method should be in format `final sha3 = Digest("SHA3-256")`, consequently this request fixes this problem.

[This line](https://github.com/bcgit/pc-dart/blob/master/lib/digests/sha3.dart#L14) proves this point.