### PR TITLE
ASN1Utils Fix calculate start position

### DIFF
--- a/lib/asn1/asn1_utils.dart
+++ b/lib/asn1/asn1_utils.dart
@@ -14,7 +14,7 @@ class ASN1Utils {
   ///
   static int calculateValueStartPosition(Uint8List encodedBytes) {
     var length = encodedBytes[1];
-    if (length < 0x7F) {
+    if (length <= 0x7F) {
       return 2;
     } else {
       return 2 + (length & 0x7F);


### PR DESCRIPTION
This PR improves the calculation of the start position of the values. This code now calculates the position in the right way if the byte length is equal to 127 according to issue #90 .