### PR TITLE
Improve ASN1 Dump

### DIFF
--- a/lib/asn1/asn1_object.dart
+++ b/lib/asn1/asn1_object.dart
@@ -129,11 +129,14 @@ class ASN1Object {
     if (tag == 0xA0 || tag == 0xA3) {
       sb.write('[$tag]');
       var parser = ASN1Parser(valueBytes);
-      var next = parser.nextObject();
-      var dump = next.dump(spaces: spaces + dumpIndent);
-      sb.write('\n$dump');
+      if (parser.hasNext()) {
+        var next = parser.nextObject();
+        var dump = next.dump(spaces: spaces + dumpIndent);
+        sb.write('\n$dump');
+      } else {
+        sb.write(' (0 elem)');
+      }
     }
-    sb.write('UNKNOWN');
     return sb.toString();
   }
 }

--- a/lib/asn1/object_identifiers.dart
+++ b/lib/asn1/object_identifiers.dart
@@ -261,6 +261,21 @@ class ObjectIdentifiers {
       'readableName': 'secp384r1',
       'identifier': [1, 3, 132, 0, 34],
     },
+    {
+      'identifierString': '2.5.29.15',
+      'readableName': 'keyUsage',
+      'identifier': [2, 5, 29, 15]
+    },
+    {
+      'identifierString': '2.5.29.19',
+      'readableName': 'basicConstraints',
+      'identifier': [2, 5, 29, 19]
+    },
+    {
+      'identifierString': '2.5.29.14',
+      'readableName': 'subjectKeyIdentifier',
+      'identifier': [2, 5, 29, 14]
+    },
   ];
 
   ///

--- a/lib/asn1/primitives/asn1_bit_string.dart
+++ b/lib/asn1/primitives/asn1_bit_string.dart
@@ -135,13 +135,31 @@ class ASN1BitString extends ASN1Object {
       }
     } else {
       if (ASN1Utils.isASN1Tag(stringValues!.elementAt(0))) {
+        var sb2 = StringBuffer();
+        for (var v in stringValues!) {
+          var s = v.toRadixString(2);
+          sb2.write(s);
+        }
+        var bits = sb2.toString();
+        if (unusedbits != null) {
+          bits = bits.substring(0, bits.length - unusedbits!);
+        }
         var parser = ASN1Parser(stringValues as Uint8List?);
         var next = parser.nextObject();
         var dump = next.dump(spaces: spaces + dumpIndent);
-        sb.write('BIT STRING\n$dump');
+        sb.write('BIT STRING (${(bits.length)} bit)\n$dump');
       } else {
-        sb.write(
-            'BIT STRING ${ascii.decode(stringValues!, allowInvalid: true)}');
+        var sb2 = StringBuffer();
+        for (var v in stringValues!) {
+          var s = v.toRadixString(2);
+          sb2.write(s);
+        }
+        var bits = sb2.toString();
+        if (unusedbits != null) {
+          bits = bits.substring(0, bits.length - unusedbits!);
+        }
+        sb.write('BIT STRING (${(bits.length)} bit) ');
+        sb.write(bits);
       }
     }
     return sb.toString();

--- a/lib/asn1/primitives/asn1_boolean.dart
+++ b/lib/asn1/primitives/asn1_boolean.dart
@@ -63,7 +63,7 @@ class ASN1Boolean extends ASN1Object {
     for (var i = 0; i < spaces; i++) {
       sb.write(' ');
     }
-    sb.write('Boolean $boolValue');
+    sb.write('BOOLEAN $boolValue');
     return sb.toString();
   }
 }

--- a/lib/asn1/primitives/asn1_generalized_time.dart
+++ b/lib/asn1/primitives/asn1_generalized_time.dart
@@ -73,7 +73,7 @@ class ASN1GeneralizedTime extends ASN1Object {
     for (var i = 0; i < spaces; i++) {
       sb.write(' ');
     }
-    sb.write('UTCTime ${dateTimeValue!.toIso8601String()}');
+    sb.write('GENERALIZEDTIME ${dateTimeValue!.toIso8601String()}');
     return sb.toString();
   }
 }

--- a/lib/asn1/primitives/asn1_octet_string.dart
+++ b/lib/asn1/primitives/asn1_octet_string.dart
@@ -120,13 +120,13 @@ class ASN1OctetString extends ASN1Object {
         sb.write('\n $dump');
       }
     } else {
-      if (ASN1Utils.isASN1Tag(octets!.elementAt(0))) {
-        var parser = ASN1Parser(octets);
-        var next = parser.nextObject();
-        var dump = next.dump(spaces: spaces + dumpIndent);
-        sb.write('OCTET STRING\n$dump');
-      } else {
-        sb.write('OCTET STRING ${ascii.decode(octets!, allowInvalid: true)}');
+      sb.write('OCTET STRING (${octets!.length} byte) ');
+      for (var o in octets!) {
+        var s = o.toRadixString(16).toUpperCase();
+        if (s.length == 1) {
+          s = '0$s';
+        }
+        sb.write(s);
       }
     }
     return sb.toString();

--- a/lib/asn1/primitives/asn1_printable_string.dart
+++ b/lib/asn1/primitives/asn1_printable_string.dart
@@ -117,13 +117,13 @@ class ASN1PrintableString extends ASN1Object {
       sb.write(' ');
     }
     if (isConstructed!) {
-      sb.write('PrintableString (${elements!.length} elem)');
+      sb.write('PRINTABLE STRING (${elements!.length} elem)');
       for (var e in elements!) {
         var dump = e.dump(spaces: spaces + dumpIndent);
         sb.write('\n$dump');
       }
     } else {
-      sb.write('PrintableString $stringValue');
+      sb.write('PRINTABLE STRING $stringValue');
     }
     return sb.toString();
   }

--- a/lib/asn1/primitives/asn1_set.dart
+++ b/lib/asn1/primitives/asn1_set.dart
@@ -84,7 +84,7 @@ class ASN1Set extends ASN1Object {
     for (var i = 0; i < spaces; i++) {
       sb.write(' ');
     }
-    sb.write('SEQUENCE (${elements!.length} elem)');
+    sb.write('SET (${elements!.length} elem)');
     for (var e in elements!) {
       var dump = e.dump(spaces: spaces + dumpIndent);
       sb.write('\n$dump');

--- a/lib/asn1/primitives/asn1_teletext_string.dart
+++ b/lib/asn1/primitives/asn1_teletext_string.dart
@@ -117,13 +117,13 @@ class ASN1TeletextString extends ASN1Object {
       sb.write(' ');
     }
     if (isConstructed!) {
-      sb.write('T61String (${elements!.length} elem)');
+      sb.write('T61STRING (${elements!.length} elem)');
       for (var e in elements!) {
         var dump = e.dump(spaces: spaces + dumpIndent);
         sb.write('\n $dump');
       }
     } else {
-      sb.write('T61String $stringValue');
+      sb.write('T61STRING $stringValue');
     }
     return sb.toString();
   }

--- a/lib/asn1/primitives/asn1_utc_time.dart
+++ b/lib/asn1/primitives/asn1_utc_time.dart
@@ -89,7 +89,7 @@ class ASN1UtcTime extends ASN1Object {
     for (var i = 0; i < spaces; i++) {
       sb.write(' ');
     }
-    sb.write('UTCTime ${time!.toIso8601String()}');
+    sb.write('UTCTIME ${time!.toIso8601String()}');
     return sb.toString();
   }
 }

--- a/lib/asn1/primitives/asn1_utf8_string.dart
+++ b/lib/asn1/primitives/asn1_utf8_string.dart
@@ -117,13 +117,13 @@ class ASN1UTF8String extends ASN1Object {
       sb.write(' ');
     }
     if (isConstructed!) {
-      sb.write('UTF8String (${elements!.length} elem)');
+      sb.write('UTF8STRING (${elements!.length} elem)');
       for (var e in elements!) {
         var dump = e.dump(spaces: spaces + dumpIndent);
         sb.write('\n$dump');
       }
     } else {
-      sb.write('UTF8String $utf8StringValue');
+      sb.write('UTF8STRING $utf8StringValue');
     }
     return sb.toString();
   }

--- a/test/asn1/asn1_dump_test.dart
+++ b/test/asn1/asn1_dump_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:pointycastle/asn1.dart';
+import 'package:test/test.dart';
+
+void main() {
+  ///
+  /// Helper method
+  ///
+  List<String> chunk(String s, int chunkSize) {
+    var chunked = <String>[];
+    for (var i = 0; i < s.length; i += chunkSize) {
+      var end = (i + chunkSize < s.length) ? i + chunkSize : s.length;
+      chunked.add(s.substring(i, end));
+    }
+    return chunked;
+  }
+
+  var dump1 = '''SEQUENCE (4 elem)
+  SEQUENCE (3 elem)
+    OBJECT IDENTIFIER 2.5.29.15 keyUsage
+    BOOLEAN true
+    OCTET STRING (4 byte) 03020186
+  SEQUENCE (3 elem)
+    OBJECT IDENTIFIER 2.5.29.19 basicConstraints
+    BOOLEAN true
+    OCTET STRING (5 byte) 30030101FF
+  SEQUENCE (2 elem)
+    OBJECT IDENTIFIER 2.5.29.14 subjectKeyIdentifier
+    OCTET STRING (22 byte) 041403DE503556D14CBB66F0A3E21B1BC397B23DD155
+  SEQUENCE (2 elem)
+    OBJECT IDENTIFIER 2.5.29.35 authorityKeyIdentifier
+    OCTET STRING (24 byte) 3016801403DE503556D14CBB66F0A3E21B1BC397B23DD155''';
+
+  test('Test asn1 dump', () {
+    var outer = ASN1Sequence.fromBytes(Uint8List.fromList([
+      0x30,
+      0x61,
+      0x30,
+      0x0E,
+      0x06,
+      0x03,
+      0x55,
+      0x1D,
+      0x0F,
+      0x01,
+      0x01,
+      0xFF,
+      0x04,
+      0x04,
+      0x03,
+      0x02,
+      0x01,
+      0x86,
+      0x30,
+      0x0F,
+      0x06,
+      0x03,
+      0x55,
+      0x1D,
+      0x13,
+      0x01,
+      0x01,
+      0xFF,
+      0x04,
+      0x05,
+      0x30,
+      0x03,
+      0x01,
+      0x01,
+      0xFF,
+      0x30,
+      0x1D,
+      0x06,
+      0x03,
+      0x55,
+      0x1D,
+      0x0E,
+      0x04,
+      0x16,
+      0x04,
+      0x14,
+      0x03,
+      0xDE,
+      0x50,
+      0x35,
+      0x56,
+      0xD1,
+      0x4C,
+      0xBB,
+      0x66,
+      0xF0,
+      0xA3,
+      0xE2,
+      0x1B,
+      0x1B,
+      0xC3,
+      0x97,
+      0xB2,
+      0x3D,
+      0xD1,
+      0x55,
+      0x30,
+      0x1F,
+      0x06,
+      0x03,
+      0x55,
+      0x1D,
+      0x23,
+      0x04,
+      0x18,
+      0x30,
+      0x16,
+      0x80,
+      0x14,
+      0x03,
+      0xDE,
+      0x50,
+      0x35,
+      0x56,
+      0xD1,
+      0x4C,
+      0xBB,
+      0x66,
+      0xF0,
+      0xA3,
+      0xE2,
+      0x1B,
+      0x1B,
+      0xC3,
+      0x97,
+      0xB2,
+      0x3D,
+      0xD1,
+      0x55
+    ]));
+    var chunks = chunk(base64.encode(outer.encode()), 64);
+    var pem = chunks.join('\r\n');
+
+    var lines = LineSplitter.split(pem)
+        .map((line) => line.trim())
+        .where((line) => line.isNotEmpty)
+        .toList();
+
+    var base64String = lines.join('');
+    var bytes = Uint8List.fromList(base64Decode(base64String));
+    var asn1Parser = ASN1Parser(bytes);
+    var topLevelSeq = asn1Parser.nextObject();
+    var dump = topLevelSeq.dump();
+    expect(dump, dump1);
+  });
+}

--- a/test/asn1/asn1_object_test.dart
+++ b/test/asn1/asn1_object_test.dart
@@ -88,4 +88,14 @@ void main() {
 
     expect(asn1Object.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var bytes = Uint8List.fromList([
+      0xA0,
+      0x00,
+    ]);
+
+    var asn1Object = ASN1Object.fromBytes(bytes);
+    expect('[160] (0 elem)', asn1Object.dump());
+  });
 }

--- a/test/asn1/asn1_utils_test.dart
+++ b/test/asn1/asn1_utils_test.dart
@@ -68,6 +68,32 @@ void main() {
           0x67
         ])),
         11);
+    expect(
+        ASN1Utils.decodeLength(Uint8List.fromList([
+          0x04,
+          0x14,
+          0x03,
+          0xDE,
+          0x50,
+          0x35,
+          0x56,
+          0xD1,
+          0x4C,
+          0xBB,
+          0x66,
+          0xF0,
+          0xA3,
+          0xE2,
+          0x1B,
+          0x1B,
+          0xC3,
+          0x97,
+          0xB2,
+          0x3D,
+          0xD1,
+          0x55
+        ])),
+        20);
   });
 
   test('Test encodeLength', () {

--- a/test/asn1/primitives/asn1_bit_string_test.dart
+++ b/test/asn1/primitives/asn1_bit_string_test.dart
@@ -202,4 +202,44 @@ void main() {
         asn1Object.encode(encodingRule: ASN1EncodingRule.ENCODING_BER_PADDED),
         bytes);
   });
+
+  test('Test dump', () {
+    var expected1 = '''BIT STRING (152 bit)
+  SEQUENCE (1 elem)
+    INTEGER 277839652448501959441742896570862388342''';
+    var bytes = Uint8List.fromList([
+      0x03,
+      0x16,
+      0x00,
+      0x30,
+      0x13,
+      0x02,
+      0x11,
+      0x00,
+      0xD1,
+      0x05,
+      0xF8,
+      0x7B,
+      0xCA,
+      0x00,
+      0x2A,
+      0x90,
+      0xFD,
+      0xD5,
+      0xE2,
+      0x8A,
+      0x2C,
+      0xBF,
+      0xC4,
+      0x76
+    ]);
+
+    var asn1Object = ASN1BitString.fromBytes(bytes);
+    expect(asn1Object.dump(), expected1);
+
+    var expected2 = '''BIT STRING (3 bit) 101''';
+    bytes = Uint8List.fromList([0x03, 0x02, 0x05, 0xA0]);
+    asn1Object = ASN1BitString.fromBytes(bytes);
+    expect(asn1Object.dump(), expected2);
+  });
 }

--- a/test/asn1/primitives/asn1_bit_string_test.dart
+++ b/test/asn1/primitives/asn1_bit_string_test.dart
@@ -204,7 +204,7 @@ void main() {
   });
 
   test('Test dump', () {
-    var expected1 = '''BIT STRING (152 bit)
+    var expected1 = '''BIT STRING (129 bit)
   SEQUENCE (1 elem)
     INTEGER 277839652448501959441742896570862388342''';
     var bytes = Uint8List.fromList([

--- a/test/asn1/primitives/asn1_boolean_test.dart
+++ b/test/asn1/primitives/asn1_boolean_test.dart
@@ -25,4 +25,12 @@ void main() {
 
     expect(asn1Boolean.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''BOOLEAN true''';
+    var bytes = Uint8List.fromList([0x01, 0x01, 0xFF]);
+
+    var asn1Object = ASN1Boolean.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_enumerated_test.dart
+++ b/test/asn1/primitives/asn1_enumerated_test.dart
@@ -26,4 +26,12 @@ void main() {
 
     expect(utf8String.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''INTEGER 2''';
+    var bytes = Uint8List.fromList([0x0a, 0x01, 0x02]);
+
+    var asn1Object = ASN1Enumerated.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_generalized_time_test.dart
+++ b/test/asn1/primitives/asn1_generalized_time_test.dart
@@ -80,4 +80,30 @@ void main() {
 
     expect(utf8String.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''GENERALIZEDTIME 2010-10-30T10:10:30.000Z''';
+    var bytes = Uint8List.fromList([
+      0x18,
+      0x0F,
+      0x32,
+      0x30,
+      0x31,
+      0x30,
+      0x31,
+      0x30,
+      0x33,
+      0x30,
+      0x31,
+      0x30,
+      0x31,
+      0x30,
+      0x33,
+      0x30,
+      0x5A
+    ]);
+
+    var asn1Object = ASN1GeneralizedTime.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_ia5_string_test.dart
+++ b/test/asn1/primitives/asn1_ia5_string_test.dart
@@ -408,4 +408,42 @@ void main() {
                 ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH),
         bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''IA5String https://www.digicert.com/CPS''';
+    var bytes = Uint8List.fromList([
+      0x16,
+      0x1C,
+      0x68,
+      0x74,
+      0x74,
+      0x70,
+      0x73,
+      0x3A,
+      0x2F,
+      0x2F,
+      0x77,
+      0x77,
+      0x77,
+      0x2E,
+      0x64,
+      0x69,
+      0x67,
+      0x69,
+      0x63,
+      0x65,
+      0x72,
+      0x74,
+      0x2E,
+      0x63,
+      0x6F,
+      0x6D,
+      0x2F,
+      0x43,
+      0x50,
+      0x53
+    ]);
+    var asn1Object = ASN1IA5String.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_integer_test.dart
+++ b/test/asn1/primitives/asn1_integer_test.dart
@@ -83,4 +83,31 @@ void main() {
 
     expect(utf8String.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''INTEGER 21173761728093306653035526320543534926''';
+    var bytes = Uint8List.fromList([
+      0x02,
+      0x10,
+      0x0F,
+      0xED,
+      0xEB,
+      0x0D,
+      0x80,
+      0x08,
+      0x13,
+      0x40,
+      0xC6,
+      0x44,
+      0xE4,
+      0xB7,
+      0xA6,
+      0x80,
+      0x8F,
+      0x4E
+    ]);
+
+    var asn1Object = ASN1Integer.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_null_test.dart
+++ b/test/asn1/primitives/asn1_null_test.dart
@@ -49,4 +49,12 @@ void main() {
             encodingRule: ASN1EncodingRule.ENCODING_BER_LONG_LENGTH_FORM),
         bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''NULL''';
+    var bytes = Uint8List.fromList([0x05, 0x00]);
+
+    var asn1Object = ASN1Null.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_object_identifier_test.dart
+++ b/test/asn1/primitives/asn1_object_identifier_test.dart
@@ -68,4 +68,12 @@ void main() {
     expect(asn1Object.objectIdentifier!.elementAt(3), 3);
     expect(asn1Object.objectIdentifierAsString, '2.5.4.3');
   });
+
+  test('Test dump', () {
+    var expected = '''OBJECT IDENTIFIER 2.5.4.3 commonName''';
+    var bytes = Uint8List.fromList([0x06, 0x03, 0x55, 0x04, 0x03]);
+
+    var asn1Object = ASN1ObjectIdentifier.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_octet_string_test.dart
+++ b/test/asn1/primitives/asn1_octet_string_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:pointycastle/asn1/asn1_encoding_rule.dart';
@@ -234,5 +235,13 @@ void main() {
             encodingRule:
                 ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH),
         bytes);
+  });
+
+  test('Test dump', () {
+    var expected = '''OCTET STRING
+  BIT STRING (3 bit) 101''';
+    var bytes = Uint8List.fromList([0x04, 0x04, 0x03, 0x02, 0x05, 0xA0]);
+    var asn1Object = ASN1OctetString.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
   });
 }

--- a/test/asn1/primitives/asn1_octet_string_test.dart
+++ b/test/asn1/primitives/asn1_octet_string_test.dart
@@ -238,9 +238,32 @@ void main() {
   });
 
   test('Test dump', () {
-    var expected = '''OCTET STRING
-  BIT STRING (3 bit) 101''';
-    var bytes = Uint8List.fromList([0x04, 0x04, 0x03, 0x02, 0x05, 0xA0]);
+    var expected =
+        '''OCTET STRING (20 byte) 03DE503556D14CBB66F0A3E21B1BC397B23DD155''';
+    var bytes = Uint8List.fromList([
+      0x04,
+      0x14,
+      0x03,
+      0xDE,
+      0x50,
+      0x35,
+      0x56,
+      0xD1,
+      0x4C,
+      0xBB,
+      0x66,
+      0xF0,
+      0xA3,
+      0xE2,
+      0x1B,
+      0x1B,
+      0xC3,
+      0x97,
+      0xB2,
+      0x3D,
+      0xD1,
+      0x55
+    ]);
     var asn1Object = ASN1OctetString.fromBytes(bytes);
     expect(asn1Object.dump(), expected);
   });

--- a/test/asn1/primitives/asn1_printable_string_test.dart
+++ b/test/asn1/primitives/asn1_printable_string_test.dart
@@ -270,4 +270,17 @@ void main() {
                 ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH),
         bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''PRINTABLE STRING US''';
+    var bytes = Uint8List.fromList([
+      0x13,
+      0x02,
+      0x55,
+      0x53,
+    ]);
+
+    var asn1Object = ASN1PrintableString.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_sequence_test.dart
+++ b/test/asn1/primitives/asn1_sequence_test.dart
@@ -121,4 +121,30 @@ void main() {
 
     expect(asn1Object.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''SEQUENCE (2 elem)
+  OBJECT IDENTIFIER 1.2.840.113549.1.1.11 sha256WithRSAEncryption
+  NULL''';
+    var bytes = Uint8List.fromList([
+      0x30,
+      0x0D,
+      0x06,
+      0x09,
+      0x2A,
+      0x86,
+      0x48,
+      0x86,
+      0xF7,
+      0x0D,
+      0x01,
+      0x01,
+      0x0B,
+      0x05,
+      0x00
+    ]);
+
+    var asn1Object = ASN1Sequence.fromBytes(bytes);
+    expect(expected, asn1Object.dump());
+  });
 }

--- a/test/asn1/primitives/asn1_set_test.dart
+++ b/test/asn1/primitives/asn1_set_test.dart
@@ -74,4 +74,30 @@ void main() {
 
     expect(asn1Object.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''SET (2 elem)
+  OBJECT IDENTIFIER 1.2.840.113549.1.1.11 sha256WithRSAEncryption
+  NULL''';
+    var bytes = Uint8List.fromList([
+      0x31,
+      0x0D,
+      0x06,
+      0x09,
+      0x2A,
+      0x86,
+      0x48,
+      0x86,
+      0xF7,
+      0x0D,
+      0x01,
+      0x01,
+      0x0B,
+      0x05,
+      0x00
+    ]);
+
+    var asn1Object = ASN1Set.fromBytes(bytes);
+    expect(expected, asn1Object.dump());
+  });
 }

--- a/test/asn1/primitives/asn1_teletext_string_test.dart
+++ b/test/asn1/primitives/asn1_teletext_string_test.dart
@@ -169,4 +169,71 @@ void main() {
   test('Test encode BER Constructed Indefinite Length', () {
     // TODO Create test
   });
+
+  test('Test dump', () {
+    var expected =
+        '''T61STRING www.entrust.net/CPS_2048 incorp. by ref. (limits liab.)''';
+    var bytes = Uint8List.fromList([
+      0x14,
+      0x37,
+      0x77,
+      0x77,
+      0x77,
+      0x2E,
+      0x65,
+      0x6E,
+      0x74,
+      0x72,
+      0x75,
+      0x73,
+      0x74,
+      0x2E,
+      0x6E,
+      0x65,
+      0x74,
+      0x2F,
+      0x43,
+      0x50,
+      0x53,
+      0x5F,
+      0x32,
+      0x30,
+      0x34,
+      0x38,
+      0x20,
+      0x69,
+      0x6E,
+      0x63,
+      0x6F,
+      0x72,
+      0x70,
+      0x2E,
+      0x20,
+      0x62,
+      0x79,
+      0x20,
+      0x72,
+      0x65,
+      0x66,
+      0x2E,
+      0x20,
+      0x28,
+      0x6C,
+      0x69,
+      0x6D,
+      0x69,
+      0x74,
+      0x73,
+      0x20,
+      0x6C,
+      0x69,
+      0x61,
+      0x62,
+      0x2E,
+      0x29
+    ]);
+
+    var asn1Object = ASN1TeletextString.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_utc_time_test.dart
+++ b/test/asn1/primitives/asn1_utc_time_test.dart
@@ -74,4 +74,28 @@ void main() {
 
     expect(asn1Object.encode(), bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''UTCTIME 2020-07-10T00:00:00.000Z''';
+    var bytes = Uint8List.fromList([
+      0x17,
+      0x0D,
+      0x32,
+      0x30,
+      0x30,
+      0x37,
+      0x31,
+      0x30,
+      0x30,
+      0x30,
+      0x30,
+      0x30,
+      0x30,
+      0x30,
+      0x5A
+    ]);
+
+    var asn1Object = ASN1UtcTime.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }

--- a/test/asn1/primitives/asn1_utf8_string_test.dart
+++ b/test/asn1/primitives/asn1_utf8_string_test.dart
@@ -287,4 +287,26 @@ void main() {
                 ASN1EncodingRule.ENCODING_BER_CONSTRUCTED_INDEFINITE_LENGTH),
         bytes);
   });
+
+  test('Test dump', () {
+    var expected = '''UTF8STRING Hello World''';
+    var bytes = Uint8List.fromList([
+      0x0C,
+      0x0B,
+      0x48,
+      0x65,
+      0x6C,
+      0x6C,
+      0x6F,
+      0x20,
+      0x57,
+      0x6F,
+      0x72,
+      0x6C,
+      0x64
+    ]);
+
+    var asn1Object = ASN1UTF8String.fromBytes(bytes);
+    expect(asn1Object.dump(), expected);
+  });
 }


### PR DESCRIPTION
I improved the dump functionality for each ASN1 object. The structure of the dump is quite similar to https://lapo.it/asn1js.

- Improved dump() method for some objects
- Added unit tests for each ASN1 object