### PR TITLE
Improve scrypt performance

### DIFF
--- a/test/key_derivators/scrypt_test.dart
+++ b/test/key_derivators/scrypt_test.dart
@@ -22,11 +22,9 @@ void main() {
         16384, 8, 1, 64, createUint8ListFromString('SodiumChloride')),
     'pleaseletmein',
     '7023bdcb3afd7348461c06cd81fd38ebfda8fbba904f8e3ea9b543f6545da1f2d5432955613f0fcf62d49705242a9af9e61e85dc0d651e40dfcf017b45575887',
-
-    /* This test ends with an out of memory error. Too much for Dart VM :-(.
-    ScryptParameters( 1048576, 8, 1, 64, createUint8ListFromString('SodiumChloride') ),
+    ScryptParameters(
+        1048576, 8, 1, 64, createUint8ListFromString('SodiumChloride')),
     'pleaseletmein',
     '2101cb9b6a511aaeaddbbe09cf70f881ec568d574a2ffd4dabe5ee9820adaa478e56fd8f4ba5d09ffa1c6d927c40f4c337304049e8a952fbcbf45c6fa77a41a4',
-    */
   ]);
 }


### PR DESCRIPTION
In previous code, `scrypt._arraycopy` method calls an unnecessary `Uint8List.sublist`, which will make a copy of the origin `Uint8List`.
This PR tries to use less copy and object conversion to provide a better performance.

Related issue:
#134 