### PR TITLE
Keccak processed data length bugfix

### DIFF
--- a/lib/src/impl/keccak_engine.dart
+++ b/lib/src/impl/keccak_engine.dart
@@ -95,7 +95,7 @@ abstract class KeccakEngine extends BaseDigest {
 
   @override
   void updateByte(int inp) {
-    _doUpdate(Uint8List.fromList([inp]), 0, 8);
+    _doUpdate(Uint8List.fromList([inp]), 0, 1);
   }
 
   @override

--- a/lib/src/impl/keccak_engine.dart
+++ b/lib/src/impl/keccak_engine.dart
@@ -173,8 +173,8 @@ abstract class KeccakEngine extends BaseDigest {
     _dataQueue.fillRange(off, off + len, 0);
   }
 
-  void _doUpdate(Uint8List data, int off, int databitlen) {
-    absorbRange(data, off, databitlen);
+  void _doUpdate(Uint8List data, int off, int len) {
+    absorbRange(data, off, len);
   }
 
   void init(int bitlen) {


### PR DESCRIPTION
Changes to `updateByte` function of Keccak. 

Despite being stated as `databitlen` as a name of the third input of `_doUpdate` function, it appeared to be `len` (i.e. length in bytes) according to the way this input is processed in further `absorbRange` function. Therefore the bug appears, when `updateByte` function is called (by HMAC computation, for instance, see [here](https://github.com/bcgit/pc-dart/blob/master/lib/macs/hmac.dart#L95) the aforementioned calling).

Therefore this pull request fixes the bug and refactors the variable's name.