### PR TITLE
Added support for OID emailAddress

### DIFF
--- a/lib/asn1/object_identifiers.dart
+++ b/lib/asn1/object_identifiers.dart
@@ -330,6 +330,11 @@ class ObjectIdentifiers {
       'identifierString': '0.9.2342.19200300.100.1.1',
       'readableName': 'UID',
       'identifier': [0, 9, 2342, 19200300, 100, 1, 1]
+    },
+    {
+      'identifierString': '1.2.840.113549.1.9.1',
+      'readableName': 'emailAddress',
+      'identifier': [1, 2, 840, 113549, 1, 9, 1]
     }
   ];
 


### PR DESCRIPTION
The OID emailAddress is still used for example via OpenSSL although this has already been marked as deprecated. To support parsing of CSR that were generated via OpenSSL, we have to add this OID.