### PR TITLE
AES GCM now working in flutter web

### DIFF
--- a/lib/block/modes/gcm.dart
+++ b/lib/block/modes/gcm.dart
@@ -78,7 +78,7 @@ class GCMBlockCipher extends BaseAEADBlockCipher {
       counter[15] = 1;
     } else {
       _gHASH(counter, iv);
-      var length = Uint8List.view((Uint64List(2)..[0] = iv.length * 8).buffer);
+      var length = Uint8List.view((Uint32List(4)..[0] = iv.length * 8).buffer);
       length = Uint8List.fromList(length.reversed.toList());
 
       _gHASHBlock(counter, length);
@@ -190,8 +190,8 @@ class GCMBlockCipher extends BaseAEADBlockCipher {
         ? processBlock(remainingInput, 0, out, outOff)
         : 0;
 
-    var len = Uint8List.view((Uint64List(2)
-          ..[1] = aad!.length * 8
+    var len = Uint8List.view((Uint32List(4)
+          ..[2] = aad!.length * 8
           ..[0] = _processedBytes * 8)
         .buffer);
     len = Uint8List.fromList(len.reversed.toList());


### PR DESCRIPTION
AES GCM used `UInt64List` which is not available on flutter web. This PR changes it to use `UInt32List` instead which should be sufficient for all practical purposes. This allows usage on flutter web.

See #178 and also this [stackoverflow question](https://stackoverflow.com/questions/74523047/uint64list-not-supported-on-flutter-web/74526125#74526125) for context.