### PR TITLE
Improve PSS Signer and add new object identifiers

### DIFF
--- a/lib/asn1/object_identifiers.dart
+++ b/lib/asn1/object_identifiers.dart
@@ -355,6 +355,31 @@ class ObjectIdentifiers {
       'identifierString': '2.23.140.1.2.2',
       'readableName': 'organization-validated',
       'identifier': [2,23,140,1,2,2]
+    },
+        {
+      'identifierString': '1.2.840.113549.1.1.10',
+      'readableName': 'rsaPSS',
+      'identifier': [1,2,840,113549,1,1,10]
+    },
+    {
+      'identifierString': '12.16.840.1.101.3.4.2.1',
+      'readableName': 'SHA-256',
+      'identifier': [2,16,840,1,101,3,4,2,1]
+    },
+    {
+      'identifierString': '12.16.840.1.101.3.4.2.2',
+      'readableName': 'SHA-384',
+      'identifier': [2,16,840,1,101,3,4,2,2]
+    },
+    {
+      'identifierString': '12.16.840.1.101.3.4.2.3',
+      'readableName': 'SHA-512',
+      'identifier': [2,16,840,1,101,3,4,2,3]
+    },
+    {
+      'identifierString': '12.16.840.1.101.3.4.2.4',
+      'readableName': 'SHA-224',
+      'identifier': [2,16,840,1,101,3,4,2,4]
     }
   ];
 

--- a/lib/signers/pss_signer.dart
+++ b/lib/signers/pss_signer.dart
@@ -83,10 +83,6 @@ class PSSSigner implements Signer {
       throw ArgumentError('Verification requires public key');
     }
 
-    if (!forSigning && !_sSet) {
-      throw ArgumentError('Verification requires salt');
-    }
-
     _emBits = k.modulus!.bitLength - 1;
 
     if (_emBits < (8 * _hLen + 8 * _sLen + 9)) {

--- a/test/signers/pss_signer_test.dart
+++ b/test/signers/pss_signer_test.dart
@@ -5,6 +5,7 @@ library test.signers.pss_signer_test;
 import 'dart:typed_data';
 
 import 'package:pointycastle/pointycastle.dart';
+import 'package:pointycastle/random/fortuna_random.dart';
 import 'package:test/test.dart';
 
 import '../test/src/helpers.dart';
@@ -214,10 +215,12 @@ void main() {
   });
 }
 
-var pubParams = (RSAPublicKey pubk, Uint8List salt) => () => ParametersWithSalt(
-      PublicKeyParameter<RSAPublicKey>(pubk),
-      salt,
-    );
+var pubParams = (RSAPublicKey pubk, Uint8List salt) =>
+    () => ParametersWithSaltConfiguration(
+          PublicKeyParameter<RSAPublicKey>(pubk),
+          FortunaRandom(),
+          salt.length,
+        );
 var privParams = (RSAPrivateKey privk, Uint8List salt) =>
     () => ParametersWithSalt(PrivateKeyParameter<RSAPrivateKey>(privk), salt);
 


### PR DESCRIPTION
### PSS SIGNER
I fixed the PSS Signer to not require the complete Salt for verification by removing the following check :

```dart
if (!forSigning && !_sSet) {
      throw ArgumentError('Verification requires salt');
}
```
In the **verification()** method, only the field **_sLen** is used, so it is possible to use init() with a **ParametersWithSaltConfiguration** model. I updated the unit tests to use **ParametersWithSaltConfiguration** for verification.

### OBJECT IDENTIFIER

Added :
- 1.2.840.113549.1.1.10 = rsaPSS
- 2.16.840.1.101.3.4.2.1 = SHA-256
- 2.16.840.1.101.3.4.2.2 = SHA-384
- 2.16.840.1.101.3.4.2.3 = SHA-512
- 2.16.840.1.101.3.4.2.4 = SHA-224