### PR TITLE
feat: add generics to generateKeyPair

### DIFF
--- a/lib/key_generators/ec_key_generator.dart
+++ b/lib/key_generators/ec_key_generator.dart
@@ -34,7 +34,7 @@ class ECKeyGenerator implements KeyGenerator {
   }
 
   @override
-  AsymmetricKeyPair generateKeyPair() {
+  AsymmetricKeyPair<ECPublicKey, ECPrivateKey> generateKeyPair() {
     var n = _params.n;
     var nBitLength = n.bitLength;
     BigInt? d;

--- a/lib/key_generators/rsa_key_generator.dart
+++ b/lib/key_generators/rsa_key_generator.dart
@@ -41,7 +41,7 @@ class RSAKeyGenerator implements KeyGenerator {
   }
 
   @override
-  AsymmetricKeyPair generateKeyPair() {
+  AsymmetricKeyPair<RSAPublicKey, RSAPrivateKey> generateKeyPair() {
     BigInt p, q, n, e;
 
     // p and q values should have a length of half the strength in bits

--- a/tutorials/examples/rsa-demo.dart
+++ b/tutorials/examples/rsa-demo.dart
@@ -54,8 +54,8 @@ AsymmetricKeyPair<RSAPublicKey, RSAPrivateKey> generateRSAkeyPair(
 
   // Cast the generated key pair into the RSA key types
 
-  final myPublic = pair.publicKey as RSAPublicKey;
-  final myPrivate = pair.privateKey as RSAPrivateKey;
+  final myPublic = pair.publicKey;
+  final myPrivate = pair.privateKey;
 
   // The RSA numbers will always satisfy these properties
 


### PR DESCRIPTION
This PR adds a generic type to the return type so we the consumer don't need to cast anymore.