### PR TITLE
fix: non-nullable error

### DIFF
--- a/lib/key_derivators/argon2_native_int_impl.dart
+++ b/lib/key_derivators/argon2_native_int_impl.dart
@@ -21,10 +21,6 @@ import 'api.dart';
 /// The linked project was adapted for the purposes of this project, since it
 /// is a 1:1 port of BouncyCastle's Java implementation.
 class Argon2BytesGenerator extends BaseKeyDerivator {
-  Argon2BytesGenerator() {
-    Platform.instance.assertFullWidthInteger();
-  }
-
   static const int ARGON2_BLOCK_SIZE = 1024;
   static const int ARGON2_QWORDS_IN_BLOCK = ARGON2_BLOCK_SIZE ~/ 8;
 
@@ -58,6 +54,10 @@ class Argon2BytesGenerator extends BaseKeyDerivator {
 
   static final FactoryConfig factoryConfig =
       StaticFactoryConfig(KeyDerivator, 'argon2', () => Argon2BytesGenerator());
+
+  Argon2BytesGenerator() {
+    Platform.instance.assertFullWidthInteger();
+  }
 
   Argon2Parameters get parameters => _parameters;
 
@@ -578,12 +578,12 @@ class _FillBlock {
 }
 
 class _Block {
-  _Block();
-
   static const int SIZE = Argon2BytesGenerator.ARGON2_QWORDS_IN_BLOCK;
 
   /// 128 * 8 Byte QWords.
   final Uint64List _v = Uint64List(SIZE);
+
+  _Block();
 
   void fromBytes(Uint8List input) {
     if (input.length < Argon2BytesGenerator.ARGON2_BLOCK_SIZE) {
@@ -642,11 +642,11 @@ class _Block {
 }
 
 class _Position {
-  _Position();
-
   int pass = 0;
   int lane = 0;
   int slice = 0;
+
+  _Position();
 }
 
 extension _SetFrom<T> on List<T> {

--- a/lib/key_derivators/argon2_native_int_impl.dart
+++ b/lib/key_derivators/argon2_native_int_impl.dart
@@ -21,6 +21,10 @@ import 'api.dart';
 /// The linked project was adapted for the purposes of this project, since it
 /// is a 1:1 port of BouncyCastle's Java implementation.
 class Argon2BytesGenerator extends BaseKeyDerivator {
+  Argon2BytesGenerator() {
+    Platform.instance.assertFullWidthInteger();
+  }
+
   static const int ARGON2_BLOCK_SIZE = 1024;
   static const int ARGON2_QWORDS_IN_BLOCK = ARGON2_BLOCK_SIZE ~/ 8;
 
@@ -54,10 +58,6 @@ class Argon2BytesGenerator extends BaseKeyDerivator {
 
   static final FactoryConfig factoryConfig =
       StaticFactoryConfig(KeyDerivator, 'argon2', () => Argon2BytesGenerator());
-
-  Argon2BytesGenerator() {
-    Platform.instance.assertFullWidthInteger();
-  }
 
   Argon2Parameters get parameters => _parameters;
 
@@ -578,12 +578,12 @@ class _FillBlock {
 }
 
 class _Block {
+  _Block();
+
   static const int SIZE = Argon2BytesGenerator.ARGON2_QWORDS_IN_BLOCK;
 
   /// 128 * 8 Byte QWords.
   final Uint64List _v = Uint64List(SIZE);
-
-  _Block();
 
   void fromBytes(Uint8List input) {
     if (input.length < Argon2BytesGenerator.ARGON2_BLOCK_SIZE) {
@@ -642,11 +642,11 @@ class _Block {
 }
 
 class _Position {
-  int pass;
-  int lane;
-  int slice;
+  _Position();
 
-  _Position([this.pass = 0, this.lane = 0, this.slice = 0]);
+  int pass = 0;
+  int lane = 0;
+  int slice = 0;
 }
 
 extension _SetFrom<T> on List<T> {


### PR DESCRIPTION
I got the following error multiple times:
```
hosted/pub.dev/pointycastle-3.7.3/lib/key_derivators/argon2_native_int_impl.dart:645:7: Error: Field 'pass' should be initialized because its type 'int' doesn't allow null.
  int pass;
      ^^^^
hosted/pub.dev/pointycastle-3.7.3/lib/key_derivators/argon2_native_int_impl.dart:646:7: Error: Field 'lane' should be initialized because its type 'int' doesn't allow null.
  int lane;
      ^^^^
hosted/pub.dev/pointycastle-3.7.3/lib/key_derivators/argon2_native_int_impl.dart:647:7: Error: Field 'slice' should be initialized because its type 'int' doesn't allow null.
  int slice;
      ^^^^^
```

With overridden dependencies on the failing command it works from my fork now.