### PR TITLE
Support parsing of nested objects with indefinite lengths

### DIFF
--- a/lib/asn1/asn1_parser.dart
+++ b/lib/asn1/asn1_parser.dart
@@ -55,7 +55,8 @@ class ASN1Parser {
     // Get the length of the value bytes for the current object
     var length = ASN1Utils.decodeLength(bytes!.sublist(_position));
 
-    var valueStartPosition = ASN1Utils.calculateValueStartPosition(bytes!.sublist(_position));
+    var valueStartPosition =
+        ASN1Utils.calculateValueStartPosition(bytes!.sublist(_position));
 
     var isIndefiniteLength = false;
 
@@ -88,7 +89,8 @@ class ASN1Parser {
     }
 
     // Update the position
-    _position = _position + obj.totalEncodedByteLength + (isIndefiniteLength ? 2 : 0);
+    _position =
+        _position + obj.totalEncodedByteLength + (isIndefiniteLength ? 2 : 0);
     return obj;
   }
 

--- a/lib/asn1/asn1_parser.dart
+++ b/lib/asn1/asn1_parser.dart
@@ -55,9 +55,14 @@ class ASN1Parser {
     // Get the length of the value bytes for the current object
     var length = ASN1Utils.decodeLength(bytes!.sublist(_position));
 
-    var valueStartPosition =
-        ASN1Utils.calculateValueStartPosition(bytes!.sublist(_position));
-    if (_position < length + valueStartPosition) {
+    var valueStartPosition = ASN1Utils.calculateValueStartPosition(bytes!.sublist(_position));
+
+    var isIndefiniteLength = false;
+
+    if (length == -1) {
+      length = ASN1Utils.calculateIndefiniteLength(bytes!, _position) + 2;
+      isIndefiniteLength = true;
+    } else if (_position < length + valueStartPosition) {
       length = length + valueStartPosition;
     } else {
       length = bytes!.length - _position;
@@ -83,7 +88,7 @@ class ASN1Parser {
     }
 
     // Update the position
-    _position = _position + obj.totalEncodedByteLength;
+    _position = _position + obj.totalEncodedByteLength + (isIndefiniteLength ? 2 : 0);
     return obj;
   }
 

--- a/lib/asn1/asn1_utils.dart
+++ b/lib/asn1/asn1_utils.dart
@@ -127,21 +127,24 @@ class ASN1Utils {
     var currentPosition = startPosition;
     var indefiniteLengthObjects = 0;
     while (currentPosition < bytes.length - 1) {
-      if (bytes[currentPosition] == 0x00 && bytes[currentPosition + 1] == 0x00) {
+      if (bytes[currentPosition] == 0x00 &&
+          bytes[currentPosition + 1] == 0x00) {
         indefiniteLengthObjects--;
         if (indefiniteLengthObjects == 0) {
           return currentPosition - startPosition;
         }
         currentPosition += 2;
       } else {
-        final nextLength = ASN1Utils.decodeLength(bytes.sublist(currentPosition));
-        final valueStartPosition =
-            ASN1Utils.calculateValueStartPosition(bytes.sublist(currentPosition));
+        final nextLength =
+            ASN1Utils.decodeLength(bytes.sublist(currentPosition));
+        final valueStartPosition = ASN1Utils.calculateValueStartPosition(
+            bytes.sublist(currentPosition));
         if (nextLength == 0) {
           throw ArgumentError('Invalid length of zero.');
         }
         if (valueStartPosition <= 0) {
-          throw ArgumentError('Invalid value start position: $valueStartPosition');
+          throw ArgumentError(
+              'Invalid value start position: $valueStartPosition');
         }
 
         if (nextLength == -1) {
@@ -156,7 +159,8 @@ class ASN1Utils {
     throw ArgumentError('End of content octets not found');
   }
 
-  static Uint8List getBytesFromPEMString(String pem, {bool checkHeader = true}) {
+  static Uint8List getBytesFromPEMString(String pem,
+      {bool checkHeader = true}) {
     var lines = LineSplitter.split(pem)
         .map((line) => line.trim())
         .where((line) => line.isNotEmpty)
@@ -177,7 +181,8 @@ class ASN1Utils {
     return Uint8List.fromList(base64Decode(base64));
   }
 
-  static ECPrivateKey ecPrivateKeyFromDerBytes(Uint8List bytes, {bool pkcs8 = false}) {
+  static ECPrivateKey ecPrivateKeyFromDerBytes(Uint8List bytes,
+      {bool pkcs8 = false}) {
     var asn1Parser = ASN1Parser(bytes);
     var topLevelSeq = asn1Parser.nextObject() as ASN1Sequence;
     var curveName;
@@ -195,12 +200,14 @@ class ASN1Utils {
       var octetString = topLevelSeq.elements!.elementAt(2) as ASN1OctetString;
       asn1Parser = ASN1Parser(octetString.valueBytes);
       var octetStringSeq = asn1Parser.nextObject() as ASN1Sequence;
-      var octetStringKeyData = octetStringSeq.elements!.elementAt(1) as ASN1OctetString;
+      var octetStringKeyData =
+          octetStringSeq.elements!.elementAt(1) as ASN1OctetString;
 
       x = octetStringKeyData.valueBytes!;
     } else {
       // Parse the SEC1 format
-      var privateKeyAsOctetString = topLevelSeq.elements!.elementAt(1) as ASN1OctetString;
+      var privateKeyAsOctetString =
+          topLevelSeq.elements!.elementAt(1) as ASN1OctetString;
       var choice = topLevelSeq.elements!.elementAt(2);
       var s = ASN1Sequence();
       var parser = ASN1Parser(choice.valueBytes);
@@ -208,7 +215,8 @@ class ASN1Utils {
         s.add(parser.nextObject());
       }
       var curveNameOi = s.elements!.elementAt(0) as ASN1ObjectIdentifier;
-      var data = ObjectIdentifiers.getIdentifierByIdentifier(curveNameOi.objectIdentifierAsString);
+      var data = ObjectIdentifiers.getIdentifierByIdentifier(
+          curveNameOi.objectIdentifierAsString);
       if (data != null) {
         curveName = data['readableName'];
       }

--- a/test/asn1/primitives/asn1_sequence_test.dart
+++ b/test/asn1/primitives/asn1_sequence_test.dart
@@ -1,6 +1,7 @@
 import 'dart:typed_data';
 
 import 'package:pointycastle/asn1/primitives/asn1_ia5_string.dart';
+import 'package:pointycastle/asn1/primitives/asn1_integer.dart';
 import 'package:pointycastle/asn1/primitives/asn1_null.dart';
 import 'package:pointycastle/asn1/primitives/asn1_object_identifier.dart';
 import 'package:pointycastle/asn1/primitives/asn1_sequence.dart';
@@ -57,6 +58,108 @@ void main() {
     expect(asn1Object.elements!.length, 2);
     expect(asn1Object.elements!.elementAt(0) is ASN1ObjectIdentifier, true);
     expect(asn1Object.elements!.elementAt(1) is ASN1Null, true);
+  });
+
+  test('Test named constructor fromBytes with nested indefinite length', () {
+    /*
+    SEQUENCE (3 elem, indefinite length)
+      INTEGER 1
+      SEQUENCE (1 elem, indefinite length)
+        OBJECT IDENTIFIER 1.2.840.113549.1.7.1 data (PKCS #7)
+      INTEGER 1
+    */
+    var bytes = Uint8List.fromList([
+      0x30,
+      0x80,
+      0x02,
+      0x01,
+      0x01,
+      0x30,
+      0x80,
+      0x06,
+      0x09,
+      0x2A,
+      0x86,
+      0x48,
+      0x86,
+      0xF7,
+      0x0D,
+      0x01,
+      0x07,
+      0x01,
+      0x00,
+      0x00,
+      0x02,
+      0x01,
+      0x01,
+      0x00,
+      0x00
+    ]);
+
+    var valueBytes = Uint8List.fromList([
+      0x02,
+      0x01,
+      0x01,
+      0x30,
+      0x80,
+      0x06,
+      0x09,
+      0x2A,
+      0x86,
+      0x48,
+      0x86,
+      0xF7,
+      0x0D,
+      0x01,
+      0x07,
+      0x01,
+      0x00,
+      0x00,
+      0x02,
+      0x01,
+      0x01,
+    ]);
+
+    var innerSequenceBytes = Uint8List.fromList([
+      0x30,
+      0x80,
+      0x06,
+      0x09,
+      0x2A,
+      0x86,
+      0x48,
+      0x86,
+      0xF7,
+      0x0D,
+      0x01,
+      0x07,
+      0x01,
+      0x00,
+      0x00
+    ]);
+
+    var innerSequenceValueBytes = Uint8List.fromList(
+        [0x06, 0x09, 0x2A, 0x86, 0x48, 0x86, 0xF7, 0x0D, 0x01, 0x07, 0x01]);
+
+    var asn1Object = ASN1Sequence.fromBytes(bytes);
+    expect(asn1Object.tag, 48);
+    expect(asn1Object.isConstructed, true);
+    expect(asn1Object.encodedBytes, bytes);
+    expect(asn1Object.valueByteLength, 21);
+    expect(asn1Object.valueStartPosition, 2);
+    expect(asn1Object.valueBytes, valueBytes);
+    expect(asn1Object.elements!.length, 3);
+    expect(asn1Object.elements!.elementAt(0) is ASN1Integer, true);
+    expect(asn1Object.elements!.elementAt(1) is ASN1Sequence, true);
+    expect(asn1Object.elements!.elementAt(2) is ASN1Integer, true);
+
+    final innerSequence = asn1Object.elements!.elementAt(1) as ASN1Sequence;
+    expect(innerSequence.tag, 48);
+    expect(innerSequence.isConstructed, true);
+    expect(innerSequence.encodedBytes, innerSequenceBytes);
+    expect(innerSequence.valueByteLength, 11);
+    expect(innerSequence.valueStartPosition, 2);
+    expect(innerSequence.valueBytes, innerSequenceValueBytes);
   });
 
   test('Test encode', () {


### PR DESCRIPTION
This pull request introduces the ability to parse nested ASN.1 objects with indefinite lengths. 
Currently, the library is not able to parse BER encoded objects that have nested objects with indefinite lengths.