### PR TITLE
Fix assert statement in aesCbcEncrypt() and aesCbcDecrypt()

### DIFF
--- a/tutorials/aes-cbc.md
+++ b/tutorials/aes-cbc.md
@@ -46,7 +46,7 @@ Uint8List aesCbcEncrypt(
     Uint8List key, Uint8List iv, Uint8List paddedPlaintext) {
   assert([128, 192, 256].contains(key.length * 8));
   assert(128 == iv.length * 8);
-  assert(128 == paddedPlaintext.length * 8);
+  assert(0 == paddedPlaintext.length % 16);
 
   // Create a CBC block cipher with AES, and initialize with key and IV
 
@@ -69,7 +69,7 @@ Uint8List aesCbcEncrypt(
 Uint8List aesCbcDecrypt(Uint8List key, Uint8List iv, Uint8List cipherText) {
   assert([128, 192, 256].contains(key.length * 8));
   assert(128 == iv.length * 8);
-  assert(128 == cipherText.length * 8);
+  assert(0 == cipherText.length % 16);
 
   // Create a CBC block cipher with AES, and initialize with key and IV
 

--- a/tutorials/examples/aes-cbc-direct.dart
+++ b/tutorials/examples/aes-cbc-direct.dart
@@ -19,7 +19,7 @@ Uint8List aesCbcEncrypt(
     Uint8List key, Uint8List iv, Uint8List paddedPlaintext) {
   assert([128, 192, 256].contains(key.length * 8));
   assert(128 == iv.length * 8);
-  assert(128 == paddedPlaintext.length * 8);
+  assert(0 == paddedPlaintext.length % 16);
 
   // Create a CBC block cipher with AES, and initialize with key and IV
 
@@ -42,7 +42,7 @@ Uint8List aesCbcEncrypt(
 Uint8List aesCbcDecrypt(Uint8List key, Uint8List iv, Uint8List cipherText) {
   assert([128, 192, 256].contains(key.length * 8));
   assert(128 == iv.length * 8);
-  assert(128 == cipherText.length * 8);
+  assert(0 == cipherText.length % 16);
 
   // Create a CBC block cipher with AES, and initialize with key and IV
 


### PR DESCRIPTION
According to the documentation

> The _paddedPlainText_ must be a multiple of the block size
(128-bits).

However the assert statement `assert(128 == paddedPlaintext.length * 8);` checks if _paddedPlaintext_ is exactly 128-bits long.

They should be switched to `assert(0 == paddedPlaintext.length % 16);` (16 bytes = 128 bits)