### PR TITLE
fix: implement validation null safety to process data and _encrypting

### DIFF
--- a/lib/padded_block_cipher/padded_block_cipher_impl.dart
+++ b/lib/padded_block_cipher/padded_block_cipher_impl.dart
@@ -49,11 +49,11 @@ class PaddedBlockCipherImpl implements PaddedBlockCipher {
   }
 
   @override
-  Uint8List process(Uint8List? data) {
-    var inputBlocks = (data!.length + blockSize - 1) ~/ blockSize;
+  Uint8List process(Uint8List data) {
+    var inputBlocks = (data.length + blockSize - 1) ~/ blockSize;
 
     int outputBlocks;
-    if (_encrypting!) {
+    if (_encrypting ?? false) {
       outputBlocks = (data.length + blockSize) ~/ blockSize;
     } else {
       if ((data.length % blockSize) != 0) {
@@ -83,7 +83,7 @@ class PaddedBlockCipherImpl implements PaddedBlockCipher {
 
   @override
   int doFinal(Uint8List inp, int inpOff, Uint8List out, int outOff) {
-    if (_encrypting!) {
+    if (_encrypting ?? false) {
       var lastInputBlock = Uint8List(blockSize)..setAll(0, inp.sublist(inpOff));
 
       var remainder = inp.length - inpOff;


### PR DESCRIPTION
Dear pointycastle team,

**Fix issue**: [**253**](https://github.com/bcgit/pc-dart/issues/253) Error: Null check operator used on a null value; in PaddedBlockCipherImpl.process #253

I identified that the issue is due to the lack of null safety checks on lines **52, 53, 56, and 86**. I have created this **PR** with a proposed solution for this problem, ensuring that the necessary null checks are implemented.

I would greatly appreciate it if you could review this PR for integration or improvement in a future release of the library.

Thank you for your attention and for the excellent work you do with pointycastle.

Best regards, Salatiel Montero.