### PR TITLE
Use process.versions.node to check for Node.js environment and increase timeout for Chrome workflow.

### DIFF
--- a/.github/workflows/chrome.workflow.yml
+++ b/.github/workflows/chrome.workflow.yml
@@ -37,4 +37,4 @@ jobs:
         run: dart pub get
 
       - name: Test chrome
-        run: dart test -j 1 -p chrome
+        run: dart test --timeout 2x -j 1 -p chrome

--- a/lib/src/platform_check/node_crypto.dart
+++ b/lib/src/platform_check/node_crypto.dart
@@ -3,6 +3,8 @@ library nodecrypto;
 
 import 'dart:js_interop';
 
+const bool isWASM = bool.fromEnvironment('dart.tool.dart2wasm');
+
 @JS()
 @staticInterop
 class Process {}
@@ -22,7 +24,7 @@ extension on Versions {
   external JSAny get node;
 }
 
-bool get isNodeJS => _process?.versions?.node != null;
+bool get isNodeDart2JS => _process?.versions?.node != null && !isWASM;
 
 @JS()
 @staticInterop

--- a/lib/src/platform_check/node_crypto.dart
+++ b/lib/src/platform_check/node_crypto.dart
@@ -5,6 +5,27 @@ import 'dart:js_interop';
 
 @JS()
 @staticInterop
+class Process {}
+
+@JS()
+@staticInterop
+class Versions {}
+
+@JS('process')
+external Process? get _process;
+
+extension on Process {
+  external Versions? get versions;
+}
+
+extension on Versions {
+  external JSAny get node;
+}
+
+bool get isNodeJS => (_process?.versions)?.node != null;
+
+@JS()
+@staticInterop
 class Crypto {}
 
 extension on Crypto {

--- a/lib/src/platform_check/node_crypto.dart
+++ b/lib/src/platform_check/node_crypto.dart
@@ -1,17 +1,20 @@
 /// Wrapper for needed NodeJS Crypto library function and require.
-library nodecryto;
+library nodecrypto;
 
 import 'dart:js_interop';
-import 'dart:js_interop_unsafe';
-
-@JS()
-external JSObject require(String id);
 
 @JS()
 @staticInterop
+class Crypto {}
+
+extension on Crypto {
+  external JSUint8Array randomBytes(int size);
+}
+
+@JS()
+external Crypto require(String id);
+
 class NodeCrypto {
-  static JSAny randomFillSync(JSAny buf) {
-    final crypto = require('crypto');
-    return crypto.callMethod('randomFillSync'.toJS, buf);
-  }
+  static JSUint8Array randomBytes(int size) =>
+      require('crypto').randomBytes(size);
 }

--- a/lib/src/platform_check/node_crypto.dart
+++ b/lib/src/platform_check/node_crypto.dart
@@ -3,7 +3,7 @@ library nodecrypto;
 
 import 'dart:js_interop';
 
-const bool isWASM = bool.fromEnvironment('dart.tool.dart2wasm');
+const bool isDart2JS = bool.fromEnvironment('dart.tool.dart2js');
 
 @JS()
 @staticInterop
@@ -24,7 +24,7 @@ extension on Versions {
   external JSAny get node;
 }
 
-bool get isNodeDart2JS => _process?.versions?.node != null && !isWASM;
+bool get isNodeDart2JS => _process?.versions?.node != null && isDart2JS;
 
 @JS()
 @staticInterop

--- a/lib/src/platform_check/node_crypto.dart
+++ b/lib/src/platform_check/node_crypto.dart
@@ -22,7 +22,7 @@ extension on Versions {
   external JSAny get node;
 }
 
-bool get isNodeJS => (_process?.versions)?.node != null;
+bool get isNodeJS => _process?.versions?.node != null;
 
 @JS()
 @staticInterop

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -21,9 +21,10 @@ class PlatformWeb extends Platform {
       // Random.secure() normally throws this error if
       // no cryptographically secure random number source is available.
     } catch (e) {
-      // For Node.js with dart2js compiler, the following error is expected.
-      if (e.runtimeType.toString() == 'UnknownJsTypeError') {
-        // This error is internal to 'dart:_js_helper'.
+      // For Node.js with dart2js compiler, the UnknownJsTypeError error is expected.
+      // This error is internal to 'dart:_js_helper' so we need to inspect the runtimeType.
+      if (!(e.runtimeType.toString() == 'UnknownJsTypeError')) {
+        rethrow;
       }
     }
   }
@@ -55,7 +56,8 @@ class _JsBuiltInEntropySource implements EntropySource {
   @override
   Uint8List getBytes(int len) {
     return Uint8List.fromList(
-        List<int>.generate(len, (i) => _src.nextInt(256)));
+      List<int>.generate(len, (i) => _src.nextInt(256)),
+    );
   }
 }
 

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -10,24 +10,9 @@ import 'platform_check.dart';
 
 class PlatformWeb extends Platform {
   static final PlatformWeb instance = PlatformWeb();
-  static bool useBuiltInRng = false;
+  static bool useBuiltInRng = !isNodeJS;
 
-  PlatformWeb() {
-    useBuiltInRng = false;
-    try {
-      Random.secure();
-      useBuiltInRng = true;
-    } on UnsupportedError {
-      // Random.secure() normally throws this error if
-      // no cryptographically secure random number source is available.
-    } catch (e) {
-      // For Node.js with dart2js compiler, the UnknownJsTypeError error is expected.
-      // This error is internal to 'dart:_js_helper' so we need to inspect the runtimeType.
-      if (!(e.runtimeType.toString() == 'UnknownJsTypeError')) {
-        rethrow;
-      }
-    }
-  }
+  const PlatformWeb();
 
   @override
   bool get isNative => false;
@@ -39,13 +24,12 @@ class PlatformWeb extends Platform {
   EntropySource platformEntropySource() {
     if (useBuiltInRng) {
       return _JsBuiltInEntropySource();
-    } else {
-      //
-      // Assume that if we cannot get a built in Secure RNG then we are
-      // probably on NodeJS.
-      //
-      return _JsNodeEntropySource();
     }
+    //
+    // Assume that if we cannot get a built in Secure RNG then we are
+    // probably on NodeJS.
+    //
+    return _JsNodeEntropySource();
   }
 }
 

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -55,20 +55,18 @@ class _JsBuiltInEntropySource implements EntropySource {
 
   @override
   Uint8List getBytes(int len) {
-    return Uint8List.fromList(
-      List<int>.generate(len, (i) => _src.nextInt(256)),
-    );
+    final Uint8List bytes = Uint8List(len);
+    for (int i = 0; i < len; i++) {
+      bytes[i] = _src.nextInt(256);
+    }
+    return bytes;
   }
 }
 
 ///
 class _JsNodeEntropySource implements EntropySource {
   @override
-  Uint8List getBytes(int len) {
-    var list = Uint8List(len);
-    NodeCrypto.randomFillSync(list.buffer.toJS);
-    return list;
-  }
+  Uint8List getBytes(int len) => NodeCrypto.randomBytes(len).toDart;
 }
 
 Platform getPlatform() => PlatformWeb.instance;

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -13,12 +13,18 @@ class PlatformWeb extends Platform {
   static bool useBuiltInRng = false;
 
   PlatformWeb() {
+    useBuiltInRng = false;
     try {
       Random.secure();
       useBuiltInRng = true;
-    } catch (_) {
-      // throws UnknownJsTypeError. See 'dart:_js_types'.
-      useBuiltInRng = false;
+    } on UnsupportedError {
+      // Random.secure() normally throws this error if
+      // no cryptographically secure random number source is available.
+    } catch (e) {
+      // For Node.js with dart2js compiler, the following error is expected.
+      if (e.runtimeType.toString() == 'UnknownJsTypeError') {
+        // This error is internal to 'dart:_js_helper'.
+      }
     }
   }
 

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -21,16 +21,8 @@ class PlatformWeb extends Platform {
   String get platform => 'web';
 
   @override
-  EntropySource platformEntropySource() {
-    if (useBuiltInRng) {
-      return _JsBuiltInEntropySource();
-    }
-    //
-    // Assume that if we cannot get a built in Secure RNG then we are
-    // probably on NodeJS.
-    //
-    return _JsNodeEntropySource();
-  }
+  EntropySource platformEntropySource() =>
+      useBuiltInRng ? _JsBuiltInEntropySource() : _JsNodeEntropySource();
 }
 
 // Uses the built in entropy source

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -16,7 +16,8 @@ class PlatformWeb extends Platform {
     try {
       Random.secure();
       useBuiltInRng = true;
-    } on UnsupportedError {
+    } catch (_) {
+      // throws UnknownJsTypeError. See 'dart:_js_types'.
       useBuiltInRng = false;
     }
   }

--- a/lib/src/platform_check/web.dart
+++ b/lib/src/platform_check/web.dart
@@ -10,7 +10,7 @@ import 'platform_check.dart';
 
 class PlatformWeb extends Platform {
   static final PlatformWeb instance = PlatformWeb();
-  static bool useBuiltInRng = !isNodeJS;
+  static bool useBuiltInRng = !isNodeDart2JS;
 
   const PlatformWeb();
 


### PR DESCRIPTION
- Prevents `PlatformWeb` from loading entropy source from null on Node.
- Node.js / Browser detection no longer relies on try/catch; replaced with null check for JavaScript [process.versions.node](https://nodejs.org/api/process.html#processversions). If it is not null, it is Node, otherwise it is probably a web browser.
- Increase timeout to 2x for Chrome tests as the default timeout is insufficient.
- Implementation no longer depends on `js_interop_unsafe`

Closes #257